### PR TITLE
feat(notebooks): поиск по названию в GET /notebooks

### DIFF
--- a/internal/notebook/delivery/http/handler.go
+++ b/internal/notebook/delivery/http/handler.go
@@ -14,7 +14,7 @@ import (
 type notebookUsecase interface {
 	Create(ctx context.Context, userID int64, title string) (*domain.Notebook, error)
 	GetByID(ctx context.Context, userID, notebookID int64) (*domain.Notebook, error)
-	ListByUser(ctx context.Context, userID int64, limit, offset int) ([]domain.Notebook, int, error)
+	ListByUser(ctx context.Context, userID int64, limit, offset int, search string) ([]domain.Notebook, int, error)
 	Update(ctx context.Context, userID, notebookID int64, title string, isPublic bool) (*domain.Notebook, error)
 	Delete(ctx context.Context, userID, notebookID int64) error
 	AddBlock(ctx context.Context, userID, notebookID int64, block *domain.Block) (*domain.Block, error)
@@ -60,8 +60,9 @@ func (h *NotebookHandler) List(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserFromContext(r.Context())
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	search := r.URL.Query().Get("search")
 
-	notebooks, total, err := h.usecase.ListByUser(r.Context(), user.ID, limit, offset)
+	notebooks, total, err := h.usecase.ListByUser(r.Context(), user.ID, limit, offset, search)
 	if err != nil {
 		mapDomainError(w, err)
 		return

--- a/internal/notebook/delivery/http/handler_test.go
+++ b/internal/notebook/delivery/http/handler_test.go
@@ -17,7 +17,7 @@ import (
 type mockNotebookUsecase struct {
 	createFn      func(ctx context.Context, userID int64, title string) (*domain.Notebook, error)
 	getByIDFn     func(ctx context.Context, userID, notebookID int64) (*domain.Notebook, error)
-	listByUserFn  func(ctx context.Context, userID int64, limit, offset int) ([]domain.Notebook, int, error)
+	listByUserFn  func(ctx context.Context, userID int64, limit, offset int, search string) ([]domain.Notebook, int, error)
 	updateFn      func(ctx context.Context, userID, notebookID int64, title string, isPublic bool) (*domain.Notebook, error)
 	deleteFn      func(ctx context.Context, userID, notebookID int64) error
 	addBlockFn    func(ctx context.Context, userID, notebookID int64, block *domain.Block) (*domain.Block, error)
@@ -39,9 +39,9 @@ func (m *mockNotebookUsecase) GetByID(ctx context.Context, userID, notebookID in
 	return nil, domain.ErrNotFound
 }
 
-func (m *mockNotebookUsecase) ListByUser(ctx context.Context, userID int64, limit, offset int) ([]domain.Notebook, int, error) {
+func (m *mockNotebookUsecase) ListByUser(ctx context.Context, userID int64, limit, offset int, search string) ([]domain.Notebook, int, error) {
 	if m.listByUserFn != nil {
-		return m.listByUserFn(ctx, userID, limit, offset)
+		return m.listByUserFn(ctx, userID, limit, offset, search)
 	}
 	return []domain.Notebook{}, 0, nil
 }
@@ -90,7 +90,7 @@ var testUser = &domain.User{ID: 1, Username: "testuser", Email: "test@example.co
 
 func TestList(t *testing.T) {
 	h := nbhttp.New(&mockNotebookUsecase{
-		listByUserFn: func(ctx context.Context, userID int64, limit, offset int) ([]domain.Notebook, int, error) {
+		listByUserFn: func(ctx context.Context, userID int64, limit, offset int, search string) ([]domain.Notebook, int, error) {
 			return []domain.Notebook{{ID: 1, Title: "Test"}}, 1, nil
 		},
 	})
@@ -100,6 +100,46 @@ func TestList(t *testing.T) {
 	h.List(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Errorf("want 200, got %d", rec.Code)
+	}
+}
+
+func TestList_SearchQueryParamPropagates(t *testing.T) {
+	gotSearch := ""
+	h := nbhttp.New(&mockNotebookUsecase{
+		listByUserFn: func(ctx context.Context, userID int64, limit, offset int, search string) ([]domain.Notebook, int, error) {
+			gotSearch = search
+			return []domain.Notebook{}, 0, nil
+		},
+	})
+	req := httptest.NewRequest("GET", "/api/v1/notebooks?limit=7&offset=0&search=foo", nil)
+	req = reqWithUser(req, testUser)
+	rec := httptest.NewRecorder()
+	h.List(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("want 200, got %d", rec.Code)
+	}
+	if gotSearch != "foo" {
+		t.Errorf("search not propagated: got %q, want %q", gotSearch, "foo")
+	}
+}
+
+func TestList_NoSearchQueryParamSendsEmpty(t *testing.T) {
+	gotSearch := "not-set"
+	h := nbhttp.New(&mockNotebookUsecase{
+		listByUserFn: func(ctx context.Context, userID int64, limit, offset int, search string) ([]domain.Notebook, int, error) {
+			gotSearch = search
+			return []domain.Notebook{}, 0, nil
+		},
+	})
+	req := httptest.NewRequest("GET", "/api/v1/notebooks?limit=7&offset=0", nil)
+	req = reqWithUser(req, testUser)
+	rec := httptest.NewRecorder()
+	h.List(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("want 200, got %d", rec.Code)
+	}
+	if gotSearch != "" {
+		t.Errorf("want empty search, got %q", gotSearch)
 	}
 }
 
@@ -240,7 +280,7 @@ func TestGetByID_WithBlocks(t *testing.T) {
 
 func TestList_Error(t *testing.T) {
 	h := nbhttp.New(&mockNotebookUsecase{
-		listByUserFn: func(ctx context.Context, userID int64, limit, offset int) ([]domain.Notebook, int, error) {
+		listByUserFn: func(ctx context.Context, userID int64, limit, offset int, search string) ([]domain.Notebook, int, error) {
 			return nil, 0, errors.New("db error")
 		},
 	})
@@ -255,7 +295,7 @@ func TestList_Error(t *testing.T) {
 
 func TestList_Conflict(t *testing.T) {
 	h := nbhttp.New(&mockNotebookUsecase{
-		listByUserFn: func(ctx context.Context, userID int64, limit, offset int) ([]domain.Notebook, int, error) {
+		listByUserFn: func(ctx context.Context, userID int64, limit, offset int, search string) ([]domain.Notebook, int, error) {
 			return nil, 0, domain.ErrConflict
 		},
 	})
@@ -270,7 +310,7 @@ func TestList_Conflict(t *testing.T) {
 
 func TestList_Unauthorized(t *testing.T) {
 	h := nbhttp.New(&mockNotebookUsecase{
-		listByUserFn: func(ctx context.Context, userID int64, limit, offset int) ([]domain.Notebook, int, error) {
+		listByUserFn: func(ctx context.Context, userID int64, limit, offset int, search string) ([]domain.Notebook, int, error) {
 			return nil, 0, domain.ErrUnauthorized
 		},
 	})
@@ -285,7 +325,7 @@ func TestList_Unauthorized(t *testing.T) {
 
 func TestList_InvalidInput(t *testing.T) {
 	h := nbhttp.New(&mockNotebookUsecase{
-		listByUserFn: func(ctx context.Context, userID int64, limit, offset int) ([]domain.Notebook, int, error) {
+		listByUserFn: func(ctx context.Context, userID int64, limit, offset int, search string) ([]domain.Notebook, int, error) {
 			return nil, 0, domain.ErrInvalidInput
 		},
 	})

--- a/internal/notebook/repository/interfaces.go
+++ b/internal/notebook/repository/interfaces.go
@@ -9,10 +9,10 @@ import (
 type NotebookRepository interface {
 	Create(ctx context.Context, notebook *domain.Notebook) (int64, error)
 	GetByID(ctx context.Context, id int64) (*domain.Notebook, error)
-	GetByOwnerID(ctx context.Context, ownerID int64, limit, offset int) ([]domain.Notebook, error)
+	GetByOwnerID(ctx context.Context, ownerID int64, limit, offset int, search string) ([]domain.Notebook, error)
 	Update(ctx context.Context, notebook *domain.Notebook) error
 	Delete(ctx context.Context, id int64) error
-	CountByOwnerID(ctx context.Context, ownerID int64) (int, error)
+	CountByOwnerID(ctx context.Context, ownerID int64, search string) (int, error)
 }
 
 type BlockRepository interface {

--- a/internal/notebook/repository/postgres/notebook.go
+++ b/internal/notebook/repository/postgres/notebook.go
@@ -43,10 +43,15 @@ func (r *NotebookRepo) GetByID(ctx context.Context, id int64) (*domain.Notebook,
 	return nb, nil
 }
 
-func (r *NotebookRepo) GetByOwnerID(ctx context.Context, ownerID int64, limit, offset int) ([]domain.Notebook, error) {
+func (r *NotebookRepo) GetByOwnerID(ctx context.Context, ownerID int64, limit, offset int, search string) ([]domain.Notebook, error) {
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, owner_id, title, is_public, created_at, updated_at FROM notebooks WHERE owner_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
-		ownerID, limit, offset,
+		`SELECT id, owner_id, title, is_public, created_at, updated_at
+		 FROM notebooks
+		 WHERE owner_id = $1
+		   AND ($2 = '' OR title ILIKE '%' || $2 || '%')
+		 ORDER BY created_at DESC
+		 LIMIT $3 OFFSET $4`,
+		ownerID, search, limit, offset,
 	)
 	if err != nil {
 		return nil, err
@@ -93,11 +98,13 @@ func (r *NotebookRepo) Update(ctx context.Context, notebook *domain.Notebook) er
 	return nil
 }
 
-func (r *NotebookRepo) CountByOwnerID(ctx context.Context, ownerID int64) (int, error) {
+func (r *NotebookRepo) CountByOwnerID(ctx context.Context, ownerID int64, search string) (int, error) {
 	var count int
 	err := r.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM notebooks WHERE owner_id = $1`,
-		ownerID,
+		`SELECT COUNT(*) FROM notebooks
+		 WHERE owner_id = $1
+		   AND ($2 = '' OR title ILIKE '%' || $2 || '%')`,
+		ownerID, search,
 	).Scan(&count)
 	return count, err
 }

--- a/internal/notebook/usecase/notebook.go
+++ b/internal/notebook/usecase/notebook.go
@@ -10,7 +10,7 @@ import (
 type NotebookService interface {
 	Create(ctx context.Context, userID int64, title string) (*domain.Notebook, error)
 	GetByID(ctx context.Context, userID, notebookID int64) (*domain.Notebook, error)
-	ListByUser(ctx context.Context, userID int64, limit, offset int) ([]domain.Notebook, int, error)
+	ListByUser(ctx context.Context, userID int64, limit, offset int, search string) ([]domain.Notebook, int, error)
 	Delete(ctx context.Context, userID, notebookID int64) error
 	Update(ctx context.Context, userID, notebookID int64, title string, isPublic bool) (*domain.Notebook, error)
 	AddBlock(ctx context.Context, userID, notebookID int64, block *domain.Block) (*domain.Block, error)
@@ -59,18 +59,18 @@ func (s *notebookService) GetByID(ctx context.Context, userID, notebookID int64)
 	return nb, nil
 }
 
-func (s *notebookService) ListByUser(ctx context.Context, userID int64, limit, offset int) ([]domain.Notebook, int, error) {
+func (s *notebookService) ListByUser(ctx context.Context, userID int64, limit, offset int, search string) ([]domain.Notebook, int, error) {
 	if limit <= 0 || limit > 100 {
 		limit = 20
 	}
 	if offset < 0 {
 		offset = 0
 	}
-	notebooks, err := s.notebookRepo.GetByOwnerID(ctx, userID, limit, offset)
+	notebooks, err := s.notebookRepo.GetByOwnerID(ctx, userID, limit, offset, search)
 	if err != nil {
 		return nil, 0, err
 	}
-	total, err := s.notebookRepo.CountByOwnerID(ctx, userID)
+	total, err := s.notebookRepo.CountByOwnerID(ctx, userID, search)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/notebook/usecase/notebook_test.go
+++ b/internal/notebook/usecase/notebook_test.go
@@ -12,10 +12,10 @@ import (
 type mockNotebookRepo struct {
 	createFn         func(ctx context.Context, nb *domain.Notebook) (int64, error)
 	getByIDFn        func(ctx context.Context, id int64) (*domain.Notebook, error)
-	getByOwnerIDFn   func(ctx context.Context, ownerID int64, limit, offset int) ([]domain.Notebook, error)
+	getByOwnerIDFn   func(ctx context.Context, ownerID int64, limit, offset int, search string) ([]domain.Notebook, error)
 	updateFn         func(ctx context.Context, nb *domain.Notebook) error
 	deleteFn         func(ctx context.Context, id int64) error
-	countByOwnerIDFn func(ctx context.Context, ownerID int64) (int, error)
+	countByOwnerIDFn func(ctx context.Context, ownerID int64, search string) (int, error)
 }
 
 func (m *mockNotebookRepo) Create(ctx context.Context, nb *domain.Notebook) (int64, error) {
@@ -32,9 +32,9 @@ func (m *mockNotebookRepo) GetByID(ctx context.Context, id int64) (*domain.Noteb
 	return nil, domain.ErrNotFound
 }
 
-func (m *mockNotebookRepo) GetByOwnerID(ctx context.Context, ownerID int64, limit, offset int) ([]domain.Notebook, error) {
+func (m *mockNotebookRepo) GetByOwnerID(ctx context.Context, ownerID int64, limit, offset int, search string) ([]domain.Notebook, error) {
 	if m.getByOwnerIDFn != nil {
-		return m.getByOwnerIDFn(ctx, ownerID, limit, offset)
+		return m.getByOwnerIDFn(ctx, ownerID, limit, offset, search)
 	}
 	return []domain.Notebook{}, nil
 }
@@ -53,9 +53,9 @@ func (m *mockNotebookRepo) Delete(ctx context.Context, id int64) error {
 	return nil
 }
 
-func (m *mockNotebookRepo) CountByOwnerID(ctx context.Context, ownerID int64) (int, error) {
+func (m *mockNotebookRepo) CountByOwnerID(ctx context.Context, ownerID int64, search string) (int, error) {
 	if m.countByOwnerIDFn != nil {
-		return m.countByOwnerIDFn(ctx, ownerID)
+		return m.countByOwnerIDFn(ctx, ownerID, search)
 	}
 	return 0, nil
 }
@@ -221,19 +221,19 @@ func TestAddBlock_TextDefaultsLanguageToPlain(t *testing.T) {
 func TestListByUser_NormalizesLimit(t *testing.T) {
 	called := false
 	nbRepo := &mockNotebookRepo{
-		getByOwnerIDFn: func(ctx context.Context, ownerID int64, limit, offset int) ([]domain.Notebook, error) {
+		getByOwnerIDFn: func(ctx context.Context, ownerID int64, limit, offset int, search string) ([]domain.Notebook, error) {
 			called = true
 			if limit != 20 {
 				t.Errorf("want limit=20, got %d", limit)
 			}
 			return []domain.Notebook{}, nil
 		},
-		countByOwnerIDFn: func(ctx context.Context, ownerID int64) (int, error) {
+		countByOwnerIDFn: func(ctx context.Context, ownerID int64, search string) (int, error) {
 			return 0, nil
 		},
 	}
 	uc := usecase.New(nbRepo, &mockBlockRepo{})
-	_, total, err := uc.ListByUser(context.Background(), 1, 0, 0)
+	_, total, err := uc.ListByUser(context.Background(), 1, 0, 0, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -291,20 +291,71 @@ func TestGetByID_BlocksError(t *testing.T) {
 
 func TestListByUser_NegativeOffset(t *testing.T) {
 	nbRepo := &mockNotebookRepo{
-		getByOwnerIDFn: func(ctx context.Context, ownerID int64, limit, offset int) ([]domain.Notebook, error) {
+		getByOwnerIDFn: func(ctx context.Context, ownerID int64, limit, offset int, search string) ([]domain.Notebook, error) {
 			if offset != 0 {
 				t.Errorf("want offset=0, got %d", offset)
 			}
 			return []domain.Notebook{}, nil
 		},
-		countByOwnerIDFn: func(ctx context.Context, ownerID int64) (int, error) {
+		countByOwnerIDFn: func(ctx context.Context, ownerID int64, search string) (int, error) {
 			return 0, nil
 		},
 	}
 	uc := usecase.New(nbRepo, &mockBlockRepo{})
-	_, _, err := uc.ListByUser(context.Background(), 1, 10, -5)
+	_, _, err := uc.ListByUser(context.Background(), 1, 10, -5, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListByUser_SearchPropagates(t *testing.T) {
+	gotSearchRepo := ""
+	gotSearchCount := ""
+	nbRepo := &mockNotebookRepo{
+		getByOwnerIDFn: func(ctx context.Context, ownerID int64, limit, offset int, search string) ([]domain.Notebook, error) {
+			gotSearchRepo = search
+			return []domain.Notebook{{ID: 1, Title: "foo test bar"}}, nil
+		},
+		countByOwnerIDFn: func(ctx context.Context, ownerID int64, search string) (int, error) {
+			gotSearchCount = search
+			return 1, nil
+		},
+	}
+	uc := usecase.New(nbRepo, &mockBlockRepo{})
+	notebooks, total, err := uc.ListByUser(context.Background(), 1, 10, 0, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotSearchRepo != "test" {
+		t.Errorf("search not propagated to GetByOwnerID: got %q", gotSearchRepo)
+	}
+	if gotSearchCount != "test" {
+		t.Errorf("search not propagated to CountByOwnerID: got %q", gotSearchCount)
+	}
+	if len(notebooks) != 1 || total != 1 {
+		t.Errorf("want 1 notebook and total=1, got %d notebooks, total=%d", len(notebooks), total)
+	}
+}
+
+func TestListByUser_EmptySearchReturnsAll(t *testing.T) {
+	nbRepo := &mockNotebookRepo{
+		getByOwnerIDFn: func(ctx context.Context, ownerID int64, limit, offset int, search string) ([]domain.Notebook, error) {
+			if search != "" {
+				t.Errorf("want empty search, got %q", search)
+			}
+			return []domain.Notebook{{ID: 1}, {ID: 2}}, nil
+		},
+		countByOwnerIDFn: func(ctx context.Context, ownerID int64, search string) (int, error) {
+			return 2, nil
+		},
+	}
+	uc := usecase.New(nbRepo, &mockBlockRepo{})
+	notebooks, total, err := uc.ListByUser(context.Background(), 1, 10, 0, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(notebooks) != 2 || total != 2 {
+		t.Errorf("want 2 notebooks, got %d, total=%d", len(notebooks), total)
 	}
 }
 


### PR DESCRIPTION
## Что сделано

- `NotebookRepository.GetByOwnerID` и `CountByOwnerID` получили параметр `search string`
- PostgreSQL-репозиторий фильтрует через `ILIKE '%' || \$2 || '%'` (case-insensitive substring по `title`). Пустой `search = ''` делает условие всегда истинным -- обратная совместимость сохранена
- Usecase `ListByUser` пробрасывает `search` в оба repo-метода
- HTTP-handler `List` читает `r.URL.Query().Get(\"search\")` и передаёт в usecase
- Обновлены сигнатуры моков в `notebook/usecase/notebook_test.go` и `notebook/delivery/http/handler_test.go`
- Новые тесты в usecase: `TestListByUser_SearchPropagates`, `TestListByUser_EmptySearchReturnsAll`
- Новые тесты в handler: `TestList_SearchQueryParamPropagates`, `TestList_NoSearchQueryParamSendsEmpty`

## Проверки

- `go build ./...` -- компилируется
- `go test -race ./...` -- все тесты зелёные
- `gofmt -l internal/ cmd/` -- чисто
- `goimports -l internal/ cmd/` -- чисто
- `act push -j lint` -- golangci-lint локально прошёл

**Автор:** @khosta77