### PR TITLE
refactor: clean architecture audit

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -38,10 +38,6 @@ type App struct {
 	runnerManager container.Manager
 }
 
-func NoOpMiddleware(next http.Handler) http.Handler {
-	return next
-}
-
 func New(cfg *config.Config) (*App, error) {
 	db, err := database.Connect(cfg.Database.DSN())
 	if err != nil {
@@ -85,7 +81,7 @@ func New(cfg *config.Config) (*App, error) {
 
 	authHandler.RegisterRoutes(mux)
 	notebookHandler.RegisterRoutes(mux, authMw)
-	runnerHandler.RegisterRoutes(mux, NoOpMiddleware)
+	runnerHandler.RegisterRoutes(mux, authMw)
 	profileHandler.RegisterRoutes(mux, authMw)
 	healthHandler.RegisterRoutes(mux)
 

--- a/internal/auth/delivery/http/handler.go
+++ b/internal/auth/delivery/http/handler.go
@@ -116,20 +116,5 @@ func clearSessionCookie(w http.ResponseWriter) {
 }
 
 func mapDomainError(w http.ResponseWriter, err error) {
-	switch {
-	case errors.Is(err, domain.ErrNotFound):
-		httputil.Error(w, http.StatusNotFound, err.Error())
-	case errors.Is(err, domain.ErrConflict):
-		httputil.Error(w, http.StatusConflict, "email or username already exists")
-	case errors.Is(err, domain.ErrSessionExpired):
-		httputil.Error(w, http.StatusUnauthorized, "session expired")
-	case errors.Is(err, domain.ErrUnauthorized):
-		httputil.Error(w, http.StatusUnauthorized, "invalid credentials")
-	case errors.Is(err, domain.ErrInvalidInput):
-		httputil.Error(w, http.StatusBadRequest, err.Error())
-	case errors.Is(err, domain.ErrForbidden):
-		httputil.Error(w, http.StatusForbidden, "access denied")
-	default:
-		httputil.Error(w, http.StatusInternalServerError, "internal server error")
-	}
+	httputil.MapDomainError(w, err)
 }

--- a/internal/notebook/delivery/http/handler.go
+++ b/internal/notebook/delivery/http/handler.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"strconv"
 
@@ -248,18 +247,5 @@ func parseBlockID(r *http.Request) (int64, error) {
 }
 
 func mapDomainError(w http.ResponseWriter, err error) {
-	switch {
-	case errors.Is(err, domain.ErrNotFound):
-		httputil.Error(w, http.StatusNotFound, err.Error())
-	case errors.Is(err, domain.ErrConflict):
-		httputil.Error(w, http.StatusConflict, "conflict")
-	case errors.Is(err, domain.ErrUnauthorized):
-		httputil.Error(w, http.StatusUnauthorized, "invalid credentials")
-	case errors.Is(err, domain.ErrInvalidInput):
-		httputil.Error(w, http.StatusBadRequest, err.Error())
-	case errors.Is(err, domain.ErrForbidden):
-		httputil.Error(w, http.StatusForbidden, "access denied")
-	default:
-		httputil.Error(w, http.StatusInternalServerError, "internal server error")
-	}
+	httputil.MapDomainError(w, err)
 }

--- a/internal/pkg/httputil/errors.go
+++ b/internal/pkg/httputil/errors.go
@@ -1,0 +1,27 @@
+package httputil
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
+)
+
+func MapDomainError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, domain.ErrNotFound):
+		Error(w, http.StatusNotFound, err.Error())
+	case errors.Is(err, domain.ErrConflict):
+		Error(w, http.StatusConflict, "email or username already exists")
+	case errors.Is(err, domain.ErrSessionExpired):
+		Error(w, http.StatusUnauthorized, "session expired")
+	case errors.Is(err, domain.ErrUnauthorized):
+		Error(w, http.StatusUnauthorized, "invalid credentials")
+	case errors.Is(err, domain.ErrInvalidInput):
+		Error(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, domain.ErrForbidden):
+		Error(w, http.StatusForbidden, "access denied")
+	default:
+		Error(w, http.StatusInternalServerError, "internal server error")
+	}
+}

--- a/internal/pkg/httputil/errors_test.go
+++ b/internal/pkg/httputil/errors_test.go
@@ -1,0 +1,40 @@
+package httputil_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/pkg/httputil"
+)
+
+func TestMapDomainError(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{"not found", domain.ErrNotFound, http.StatusNotFound},
+		{"conflict", domain.ErrConflict, http.StatusConflict},
+		{"session expired", domain.ErrSessionExpired, http.StatusUnauthorized},
+		{"unauthorized", domain.ErrUnauthorized, http.StatusUnauthorized},
+		{"invalid input", domain.ErrInvalidInput, http.StatusBadRequest},
+		{"forbidden", domain.ErrForbidden, http.StatusForbidden},
+		{"wrapped not found", fmt.Errorf("wrap: %w", domain.ErrNotFound), http.StatusNotFound},
+		{"wrapped invalid input", fmt.Errorf("wrap: %w", domain.ErrInvalidInput), http.StatusBadRequest},
+		{"unknown error", errors.New("something"), http.StatusInternalServerError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			httputil.MapDomainError(rec, tc.err)
+			if rec.Code != tc.wantStatus {
+				t.Errorf("want status %d, got %d", tc.wantStatus, rec.Code)
+			}
+		})
+	}
+}

--- a/internal/profile/delivery/http/dto.go
+++ b/internal/profile/delivery/http/dto.go
@@ -1,5 +1,35 @@
 package http
 
+import (
+	"time"
+
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
+)
+
+type UserResponse struct {
+	ID          int64     `json:"id"`
+	Username    string    `json:"username"`
+	Email       string    `json:"email"`
+	AvatarURL   string    `json:"avatar_url"`
+	Status      string    `json:"status"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+func NewUserResponse(u *domain.User) UserResponse {
+	return UserResponse{
+		ID:          u.ID,
+		Username:    u.Username,
+		Email:       u.Email,
+		AvatarURL:   u.AvatarURL,
+		Status:      u.Status,
+		Description: u.Description,
+		CreatedAt:   u.CreatedAt,
+		UpdatedAt:   u.UpdatedAt,
+	}
+}
+
 // UpdateProfileRequest is the request body for updating user profile.
 type UpdateProfileRequest struct {
 	Username    string `json:"username"`

--- a/internal/profile/delivery/http/handler.go
+++ b/internal/profile/delivery/http/handler.go
@@ -2,11 +2,9 @@ package http
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 
-	authhttp "github.com/go-park-mail-ru/2026_1_KISS/internal/auth/delivery/http"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/middleware"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/pkg/httputil"
@@ -66,7 +64,7 @@ func (h *ProfileHandler) UploadAvatar(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httputil.JSON(w, http.StatusOK, authhttp.NewUserResponse(updated))
+	httputil.JSON(w, http.StatusOK, NewUserResponse(updated))
 }
 
 // UpdateProfile handles profile field updates.
@@ -89,7 +87,7 @@ func (h *ProfileHandler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httputil.JSON(w, http.StatusOK, authhttp.NewUserResponse(updated))
+	httputil.JSON(w, http.StatusOK, NewUserResponse(updated))
 }
 
 // ChangePassword handles password changes.
@@ -134,22 +132,9 @@ func (h *ProfileHandler) ChangeEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httputil.JSON(w, http.StatusOK, authhttp.NewUserResponse(updated))
+	httputil.JSON(w, http.StatusOK, NewUserResponse(updated))
 }
 
 func mapDomainError(w http.ResponseWriter, err error) {
-	switch {
-	case errors.Is(err, domain.ErrNotFound):
-		httputil.Error(w, http.StatusNotFound, err.Error())
-	case errors.Is(err, domain.ErrConflict):
-		httputil.Error(w, http.StatusConflict, "email or username already exists")
-	case errors.Is(err, domain.ErrUnauthorized):
-		httputil.Error(w, http.StatusUnauthorized, "invalid credentials")
-	case errors.Is(err, domain.ErrInvalidInput):
-		httputil.Error(w, http.StatusBadRequest, err.Error())
-	case errors.Is(err, domain.ErrForbidden):
-		httputil.Error(w, http.StatusForbidden, "access denied")
-	default:
-		httputil.Error(w, http.StatusInternalServerError, "internal server error")
-	}
+	httputil.MapDomainError(w, err)
 }

--- a/internal/runner/delivery/runner_handler.go
+++ b/internal/runner/delivery/runner_handler.go
@@ -1,7 +1,6 @@
 package delivery
 
 import (
-	"context"
 	"net/http"
 	"strconv"
 
@@ -44,7 +43,7 @@ func (c *runnerHandler) ExecuteFromPosition(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		blockPosition = int64(0)
 	}
-	ctx := context.Background()
+	ctx := r.Context()
 	if err := c.runnerServ.StartSession(ctx, notebookID); err != nil {
 		httputil.Error(w, http.StatusInternalServerError, err.Error())
 		return
@@ -68,7 +67,7 @@ func (c *runnerHandler) ExecuteBlock(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		blockPosition = int64(0)
 	}
-	ctx := context.Background()
+	ctx := r.Context()
 	if err := c.runnerServ.StartSession(ctx, notebookID); err != nil {
 		httputil.Error(w, http.StatusInternalServerError, err.Error())
 		return
@@ -82,7 +81,7 @@ func (c *runnerHandler) ExecuteBlock(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *runnerHandler) StopExecSession(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx := r.Context()
 	notebookID, err := strconv.ParseInt(r.PathValue("notebook_id"), 10, 64)
 	if err != nil {
 		httputil.Error(w, http.StatusBadRequest, err.Error())


### PR DESCRIPTION
## Summary
- Извлечен общий `MapDomainError` в `httputil` пакет -- устранено дублирование в 3 хэндлерах
- Убран кросс-импорт `profile/delivery -> auth/delivery` -- добавлен собственный `UserResponse` DTO в profile
- Исправлен баг: runner handler использовал `context.Background()` вместо `r.Context()` (терялся request_id, cancellation, timeouts)
- Runner routes теперь защищены auth middleware (было `NoOpMiddleware` -- кто угодно мог запускать код)
- Удалена мертвая функция `NoOpMiddleware`

## Test plan
- [x] `go build ./...` проходит
- [x] `go test -race ./...` -- все тесты проходят
- [x] `golangci-lint run ./...` -- чисто
- [x] Добавлен `errors_test.go` с тестами `MapDomainError` для всех domain-ошибок