### PR TITLE
[MULTI] Возвращать частичные результаты при ошибке Run All

### DIFF
--- a/internal/runner/delivery/runner_handler.go
+++ b/internal/runner/delivery/runner_handler.go
@@ -49,7 +49,7 @@ func (c *runnerHandler) ExecuteFromPosition(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	execResult, err := c.runnerServ.ExecuteFromPosition(ctx, notebookID, int(blockPosition))
-	if err != nil {
+	if err != nil && len(execResult) == 0 {
 		httputil.Error(w, http.StatusInternalServerError, err.Error())
 		return
 	}


### PR DESCRIPTION
## Summary
- При ошибке в одном из блоков при Run All бэкенд теперь возвращает HTTP 200 с массивом частичных результатов (включая блок с ошибкой)
- Раньше: HTTP 500 без данных → все ячейки на фронте красные
- Теперь: блоки до ошибки получают корректные результаты

## Test plan
- [ ] Run All с 3 ячейками: print("hello"), raise Exception, print("world")
- [ ] Ячейка 1 показывает "hello", ячейка 2 показывает ошибку, ячейка 3 показывает "Run-all failed"