### PR TITLE
Пропускать текстовые блоки при Выполнить все, пробрасывать partial results

### DIFF
--- a/internal/runner/notebook_session/notebook_session.go
+++ b/internal/runner/notebook_session/notebook_session.go
@@ -79,6 +79,9 @@ func (s *notebookSession) ExecuteFromPosition(
 
 	for i := startPosition; i < len(blocks); i++ {
 		block := blocks[i]
+		if block.Type != "code" {
+			continue
+		}
 		state, exists := s.BlockStates[block.ID]
 		currentHash := utils.ComputeHash(block.Content)
 

--- a/internal/runner/runner_service/runner_service.go
+++ b/internal/runner/runner_service/runner_service.go
@@ -105,7 +105,7 @@ func (s *runnerService) ExecuteFromPosition(ctx context.Context, notebookID int6
 	execResults, err := nSession.ExecuteFromPosition(ctx, notebook, startPosition)
 	if err != nil {
 		logger.Error(ctx, "usecase.runner.ExecuteFromPosition", "error", err)
-		return nil, err
+		return execResults, err
 	}
 	logger.Info(ctx, "usecase.runner.ExecuteFromPosition", "notebook_id", notebookID, "results_count", len(execResults))
 	return execResults, nil


### PR DESCRIPTION
## Summary
- **Баг**: "Выполнить все" возвращало 500, если в блокноте есть текстовая ячейка. Python runner получал пустой content и отвечал 422
- **Фикс 1**: `notebook_session.go` -- блоки с `type != "code"` пропускаются в цикле `ExecuteFromPosition`
- **Фикс 2**: `runner_service.go` -- partial results пробрасываются вместе с ошибкой (`return execResults, err` вместо `return nil, err`), обеспечивая сквозную передачу: session -> service -> handler -> frontend

## Test plan
- [ ] Создать блокнот: code + text + code
- [ ] Нажать "Выполнить все" -- оба code-блока выполняются, текстовый пропускается
- [ ] Создать блокнот: code с ошибкой + code -- первый показывает ошибку, второй не выполняется (но первый результат не теряется)