### PR TITLE
[MULTI] Пропуск пустых code-ячеек + сериализация ошибки в run-all

### DIFF
--- a/internal/domain/execute.go
+++ b/internal/domain/execute.go
@@ -23,6 +23,7 @@ type BlockExecutionResult struct {
 	Stderr     []string      `json:"stderr,omitempty"`
 	Result     string        `json:"result,omitempty"`
 	Error      error         `json:"-"`
+	ErrorMsg   string        `json:"error,omitempty"`
 	ExecutedAt time.Time     `json:"executed_at"`
 	Duration   time.Duration `json:"duration"`
 }

--- a/internal/runner/notebook_session/notebook_session.go
+++ b/internal/runner/notebook_session/notebook_session.go
@@ -82,6 +82,9 @@ func (s *notebookSession) ExecuteFromPosition(
 		if block.Type != "code" {
 			continue
 		}
+		if strings.TrimSpace(block.Content) == "" {
+			continue
+		}
 		state, exists := s.BlockStates[block.ID]
 		currentHash := utils.ComputeHash(block.Content)
 
@@ -116,6 +119,7 @@ func (s *notebookSession) ExecuteFromPosition(
 					BlockID:  block.ID,
 					Position: block.Position,
 					Error:    err,
+					ErrorMsg: err.Error(),
 				})
 				return results, fmt.Errorf("block %d execution failed: %w", block.Position, err)
 			}


### PR DESCRIPTION
## Summary
- Пустые code-ячейки (content="") пропускаются в ExecuteFromPosition -- ранее отправлялись в Python runner и вызывали 422 "String should have at least 1 character", ломая всю цепочку run-all
- Добавлено поле `ErrorMsg string` в `BlockExecutionResult` (`json:"error,omitempty"`) -- при partial results (200 с массивом) фронтенд теперь видит, какой конкретно блок упал
- Связанный PR на фронте: frontend-park-mail-ru/2026_1_KISS#TBD

## Test plan
- [x] `go test ./...` -- все тесты проходят
- [x] `golangci-lint run ./...` -- чисто
- [ ] На colkiss.ru: блокнот с text + empty_code + code(print(1)) → "Выполнить все" → пустые пропущены, code выполнен