### PR TITLE
Fix deploy: git reset --hard + set -e для надежного деплоя

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,9 +49,10 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          script_stop: true
           timeout: 10m
+          command_timeout: 10m
           script: |
+            set -e
             cd /home/ubuntu/2026_1_KISS
 
             git fetch origin develop
@@ -62,7 +63,7 @@ jobs:
               exit 0
             fi
 
-            git pull origin develop
+            git reset --hard origin/develop
 
             if echo "$CHANGED" | grep -q '^build/'; then
               echo "Python runner image changed, rebuilding..."


### PR DESCRIPTION
## Summary
- `git pull` заменён на `git reset --hard origin/develop` -- исключает ошибки при divergent branches (ручные cherry-pick на сервере)
- Добавлен `set -e` -- скрипт прерывается при любой ошибке вместо тихого продолжения
- Убран невалидный input `script_stop` (не поддерживается `appleboy/ssh-action@v1`)

## Test plan
- [ ] Смержить → CI Deploy сработает → проверить `gh run view` что `git reset --hard` и `docker compose up` прошли