### PR TITLE
Feature/admin panel overhaul

### DIFF
--- a/api/proto/auth/auth.proto
+++ b/api/proto/auth/auth.proto
@@ -22,6 +22,10 @@ service AuthService {
   rpc AdminListUsers(AdminListUsersRequest) returns (AdminListUsersResponse);
   rpc AdminSetBan(AdminSetBanRequest) returns (AdminSetBanResponse);
   rpc AdminGetStats(AdminGetStatsRequest) returns (AdminGetStatsResponse);
+  rpc AdminUpdateUser(AdminUpdateUserRequest) returns (UserResponse);
+  rpc AdminResetPassword(AdminResetPasswordRequest) returns (AdminResetPasswordResponse);
+  rpc AdminSetPlan(AdminSetPlanRequest) returns (AdminSetPlanResponse);
+  rpc AdminGetActivityStats(AdminGetActivityStatsRequest) returns (AdminGetActivityStatsResponse);
 }
 
 message UserInfo {
@@ -34,6 +38,9 @@ message UserInfo {
   int64 created_at = 7;
   int64 updated_at = 8;
   bool is_admin = 9;
+  string plan = 10;
+  int64 last_active_at = 11;
+  int64 total_time_seconds = 12;
 }
 
 message RegisterRequest {
@@ -163,4 +170,49 @@ message AdminGetStatsResponse {
   int64 total_sessions = 2;
   int64 dau = 3;
   int64 mau = 4;
+  int64 total_notebooks = 5;
+}
+
+message AdminUpdateUserRequest {
+  int64 admin_user_id = 1;
+  int64 target_user_id = 2;
+  string username = 3;
+  string email = 4;
+}
+
+message AdminResetPasswordRequest {
+  int64 admin_user_id = 1;
+  int64 target_user_id = 2;
+  string new_password = 3;
+}
+
+message AdminResetPasswordResponse {}
+
+message AdminSetPlanRequest {
+  int64 admin_user_id = 1;
+  int64 target_user_id = 2;
+  string plan = 3;
+}
+
+message AdminSetPlanResponse {}
+
+message AdminGetActivityStatsRequest {
+  int64 admin_user_id = 1;
+  int32 dau_days = 2;
+  int32 mau_months = 3;
+}
+
+message DauEntry {
+  string date = 1;
+  int64 count = 2;
+}
+
+message MauEntry {
+  string month = 1;
+  int64 count = 2;
+}
+
+message AdminGetActivityStatsResponse {
+  repeated DauEntry dau = 1;
+  repeated MauEntry mau = 2;
 }

--- a/api/proto/notebook/notebook.proto
+++ b/api/proto/notebook/notebook.proto
@@ -17,6 +17,8 @@ service NotebookService {
 
   rpc AdminListNotebooks(AdminListNotebooksRequest) returns (AdminListNotebooksResponse);
   rpc AdminDeleteNotebook(AdminDeleteNotebookRequest) returns (DeleteNotebookResponse);
+  rpc AdminSetUserNotebooksPrivate(AdminSetUserNotebooksPrivateRequest) returns (AdminSetUserNotebooksPrivateResponse);
+  rpc AdminGetNotebookCount(AdminGetNotebookCountRequest) returns (AdminGetNotebookCountResponse);
 
   rpc GrantPermission(GrantPermissionRequest) returns (GrantPermissionResponse);
   rpc RevokePermission(RevokePermissionRequest) returns (RevokePermissionResponse);
@@ -178,4 +180,16 @@ message ListSharedWithUserRequest {
   int64 user_id = 1;
   int32 limit = 2;
   int32 offset = 3;
+}
+
+message AdminSetUserNotebooksPrivateRequest {
+  int64 owner_id = 1;
+}
+
+message AdminSetUserNotebooksPrivateResponse {}
+
+message AdminGetNotebookCountRequest {}
+
+message AdminGetNotebookCountResponse {
+  int64 total = 1;
 }

--- a/internal/auth/app/app.go
+++ b/internal/auth/app/app.go
@@ -55,7 +55,7 @@ func New(cfg *config.Config, grpcPort string) (*App, error) {
 
 	fs := filestorage.NewLocalStorage(cfg.Upload.Dir, "/uploads/")
 	profileUC := authusecase.NewProfileUsecase(userRepo, fs, cfg.Upload.MaxSize)
-	eventUC := authusecase.NewEventUsecase(eventRepo)
+	eventUC := authusecase.NewEventUsecase(eventRepo, userRepo)
 	adminUC := authusecase.NewAdminUsecase(userRepo, eventRepo)
 
 	lis, err := net.Listen("tcp", ":"+grpcPort)

--- a/internal/auth/grpc/server.go
+++ b/internal/auth/grpc/server.go
@@ -206,19 +206,71 @@ func (s *Server) AdminGetStats(ctx context.Context, req *pb.AdminGetStatsRequest
 	}, nil
 }
 
+func (s *Server) AdminUpdateUser(ctx context.Context, req *pb.AdminUpdateUserRequest) (*pb.UserResponse, error) {
+	user, err := s.adminUC.AdminUpdateUser(ctx, req.GetAdminUserId(), req.GetTargetUserId(), req.GetUsername(), req.GetEmail())
+	if err != nil {
+		return nil, grpcutil.DomainToGRPCError(err)
+	}
+	return &pb.UserResponse{User: userToProto(user)}, nil
+}
+
+func (s *Server) AdminResetPassword(ctx context.Context, req *pb.AdminResetPasswordRequest) (*pb.AdminResetPasswordResponse, error) {
+	if err := s.adminUC.AdminResetPassword(ctx, req.GetAdminUserId(), req.GetTargetUserId(), req.GetNewPassword()); err != nil {
+		return nil, grpcutil.DomainToGRPCError(err)
+	}
+	return &pb.AdminResetPasswordResponse{}, nil
+}
+
+func (s *Server) AdminSetPlan(ctx context.Context, req *pb.AdminSetPlanRequest) (*pb.AdminSetPlanResponse, error) {
+	if err := s.adminUC.AdminSetPlan(ctx, req.GetAdminUserId(), req.GetTargetUserId(), req.GetPlan()); err != nil {
+		return nil, grpcutil.DomainToGRPCError(err)
+	}
+	return &pb.AdminSetPlanResponse{}, nil
+}
+
+func (s *Server) AdminGetActivityStats(ctx context.Context, req *pb.AdminGetActivityStatsRequest) (*pb.AdminGetActivityStatsResponse, error) {
+	dauDays := int(req.GetDauDays())
+	if dauDays <= 0 {
+		dauDays = 30
+	}
+	mauMonths := int(req.GetMauMonths())
+	if mauMonths <= 0 {
+		mauMonths = 12
+	}
+	dau, mau, err := s.adminUC.GetActivityStats(ctx, req.GetAdminUserId(), dauDays, mauMonths)
+	if err != nil {
+		return nil, grpcutil.DomainToGRPCError(err)
+	}
+	pbDau := make([]*pb.DauEntry, len(dau))
+	for i, d := range dau {
+		pbDau[i] = &pb.DauEntry{Date: d.Date.Format("2006-01-02"), Count: d.Count}
+	}
+	pbMau := make([]*pb.MauEntry, len(mau))
+	for i, m := range mau {
+		pbMau[i] = &pb.MauEntry{Month: m.Month.Format("2006-01"), Count: m.Count}
+	}
+	return &pb.AdminGetActivityStatsResponse{Dau: pbDau, Mau: pbMau}, nil
+}
+
 func userToProto(u *domain.User) *pb.UserInfo {
 	if u == nil {
 		return nil
 	}
-	return &pb.UserInfo{
-		Id:          u.ID,
-		Username:    u.Username,
-		Email:       u.Email,
-		AvatarUrl:   u.AvatarURL,
-		Status:      u.Status,
-		Description: u.Description,
-		CreatedAt:   u.CreatedAt.Unix(),
-		UpdatedAt:   u.UpdatedAt.Unix(),
-		IsAdmin:     u.IsAdmin,
+	info := &pb.UserInfo{
+		Id:               u.ID,
+		Username:         u.Username,
+		Email:            u.Email,
+		AvatarUrl:        u.AvatarURL,
+		Status:           u.Status,
+		Description:      u.Description,
+		CreatedAt:        u.CreatedAt.Unix(),
+		UpdatedAt:        u.UpdatedAt.Unix(),
+		IsAdmin:          u.IsAdmin,
+		Plan:             u.Plan,
+		TotalTimeSeconds: u.TotalTimeSeconds,
 	}
+	if u.LastActiveAt != nil {
+		info.LastActiveAt = u.LastActiveAt.Unix()
+	}
+	return info
 }

--- a/internal/auth/grpc/server_test.go
+++ b/internal/auth/grpc/server_test.go
@@ -74,7 +74,7 @@ func setup(t *testing.T) *testEnv {
 
 	authUC := usecase.New(userRepo, sessionRepo, 24*time.Hour)
 	eventRepo := mocks.NewMockEventRepository(ctrl)
-	eventUC := usecase.NewEventUsecase(eventRepo)
+	eventUC := usecase.NewEventUsecase(eventRepo, userRepo)
 	adminUC := usecase.NewAdminUsecase(userRepo, eventRepo)
 	srv := NewServer(authUC, profileUC, eventUC, adminUC)
 

--- a/internal/auth/repository/interfaces.go
+++ b/internal/auth/repository/interfaces.go
@@ -19,6 +19,11 @@ type UserRepository interface {
 	UpdateEmail(ctx context.Context, userID int64, email string) error
 	ListAll(ctx context.Context, limit, offset int, search string) ([]domain.User, int, error)
 	SetBanned(ctx context.Context, userID int64, banned bool) error
+	CountAll(ctx context.Context) (int64, error)
+	UpdatePlan(ctx context.Context, userID int64, plan string) error
+	UpdateLastActive(ctx context.Context, userID int64, t time.Time) error
+	IncrementTotalTime(ctx context.Context, userID int64, seconds int64) error
+	AdminUpdateUser(ctx context.Context, userID int64, username, email string) error
 }
 
 type SessionRepository interface {
@@ -30,4 +35,6 @@ type SessionRepository interface {
 type EventRepository interface {
 	Create(ctx context.Context, event *domain.UserEvent) error
 	CountActiveUsers(ctx context.Context, since time.Time) (int64, error)
+	CountActiveUsersByDay(ctx context.Context, since time.Time) ([]domain.DayCount, error)
+	CountActiveUsersByMonth(ctx context.Context, since time.Time) ([]domain.MonthCount, error)
 }

--- a/internal/auth/repository/postgres/event.go
+++ b/internal/auth/repository/postgres/event.go
@@ -45,3 +45,65 @@ func (r *EventRepo) CountActiveUsers(ctx context.Context, since time.Time) (int6
 	logger.Info(ctx, "repo.events.CountActiveUsers", "duration", time.Since(start), "count", count)
 	return count, nil
 }
+
+func (r *EventRepo) CountActiveUsersByDay(ctx context.Context, since time.Time) ([]domain.DayCount, error) {
+	start := time.Now()
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT DATE(created_at) AS day, COUNT(DISTINCT user_id)
+		 FROM user_events WHERE created_at >= $1
+		 GROUP BY DATE(created_at) ORDER BY day`,
+		since,
+	)
+	if err != nil {
+		logger.Error(ctx, "repo.events.CountActiveUsersByDay", "error", err, "duration", time.Since(start))
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []domain.DayCount
+	for rows.Next() {
+		var dc domain.DayCount
+		if err := rows.Scan(&dc.Date, &dc.Count); err != nil {
+			logger.Error(ctx, "repo.events.CountActiveUsersByDay.scan", "error", err, "duration", time.Since(start))
+			return nil, err
+		}
+		result = append(result, dc)
+	}
+	if err := rows.Err(); err != nil {
+		logger.Error(ctx, "repo.events.CountActiveUsersByDay.rows", "error", err, "duration", time.Since(start))
+		return nil, err
+	}
+	logger.Info(ctx, "repo.events.CountActiveUsersByDay", "duration", time.Since(start), "entries", len(result))
+	return result, nil
+}
+
+func (r *EventRepo) CountActiveUsersByMonth(ctx context.Context, since time.Time) ([]domain.MonthCount, error) {
+	start := time.Now()
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT DATE_TRUNC('month', created_at) AS month, COUNT(DISTINCT user_id)
+		 FROM user_events WHERE created_at >= $1
+		 GROUP BY DATE_TRUNC('month', created_at) ORDER BY month`,
+		since,
+	)
+	if err != nil {
+		logger.Error(ctx, "repo.events.CountActiveUsersByMonth", "error", err, "duration", time.Since(start))
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []domain.MonthCount
+	for rows.Next() {
+		var mc domain.MonthCount
+		if err := rows.Scan(&mc.Month, &mc.Count); err != nil {
+			logger.Error(ctx, "repo.events.CountActiveUsersByMonth.scan", "error", err, "duration", time.Since(start))
+			return nil, err
+		}
+		result = append(result, mc)
+	}
+	if err := rows.Err(); err != nil {
+		logger.Error(ctx, "repo.events.CountActiveUsersByMonth.rows", "error", err, "duration", time.Since(start))
+		return nil, err
+	}
+	logger.Info(ctx, "repo.events.CountActiveUsersByMonth", "duration", time.Since(start), "entries", len(result))
+	return result, nil
+}

--- a/internal/auth/repository/postgres/user.go
+++ b/internal/auth/repository/postgres/user.go
@@ -11,6 +11,8 @@ import (
 	"github.com/lib/pq"
 )
 
+const userColumns = `id, username, email, password_hash, avatar_url, status, description, is_admin, plan, last_active_at, total_time_seconds, created_at, updated_at`
+
 type UserRepo struct {
 	db *sql.DB
 }
@@ -42,9 +44,13 @@ func (r *UserRepo) GetByID(ctx context.Context, id int64) (*domain.User, error) 
 	start := time.Now()
 	u := &domain.User{}
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, username, email, password_hash, avatar_url, status, description, is_admin, created_at, updated_at FROM users WHERE id = $1`,
-		id,
-	).Scan(&u.ID, &u.Username, &u.Email, &u.PasswordHash, &u.AvatarURL, &u.Status, &u.Description, &u.IsAdmin, &u.CreatedAt, &u.UpdatedAt)
+		`SELECT `+userColumns+` FROM users WHERE id = $1`, id,
+	).Scan(
+		&u.ID, &u.Username, &u.Email, &u.PasswordHash,
+		&u.AvatarURL, &u.Status, &u.Description, &u.IsAdmin,
+		&u.Plan, &u.LastActiveAt, &u.TotalTimeSeconds,
+		&u.CreatedAt, &u.UpdatedAt,
+	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			logger.Error(ctx, "repo.users.GetByID", "error", domain.ErrNotFound, "duration", time.Since(start), "user_id", id)
@@ -61,9 +67,13 @@ func (r *UserRepo) GetByEmail(ctx context.Context, email string) (*domain.User, 
 	start := time.Now()
 	u := &domain.User{}
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, username, email, password_hash, avatar_url, status, description, is_admin, created_at, updated_at FROM users WHERE email = $1`,
-		email,
-	).Scan(&u.ID, &u.Username, &u.Email, &u.PasswordHash, &u.AvatarURL, &u.Status, &u.Description, &u.IsAdmin, &u.CreatedAt, &u.UpdatedAt)
+		`SELECT `+userColumns+` FROM users WHERE email = $1`, email,
+	).Scan(
+		&u.ID, &u.Username, &u.Email, &u.PasswordHash,
+		&u.AvatarURL, &u.Status, &u.Description, &u.IsAdmin,
+		&u.Plan, &u.LastActiveAt, &u.TotalTimeSeconds,
+		&u.CreatedAt, &u.UpdatedAt,
+	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			logger.Error(ctx, "repo.users.GetByEmail", "error", domain.ErrNotFound, "duration", time.Since(start), "email", email)
@@ -80,9 +90,13 @@ func (r *UserRepo) GetByUsername(ctx context.Context, username string) (*domain.
 	start := time.Now()
 	u := &domain.User{}
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, username, email, password_hash, avatar_url, status, description, is_admin, created_at, updated_at FROM users WHERE username = $1`,
-		username,
-	).Scan(&u.ID, &u.Username, &u.Email, &u.PasswordHash, &u.AvatarURL, &u.Status, &u.Description, &u.IsAdmin, &u.CreatedAt, &u.UpdatedAt)
+		`SELECT `+userColumns+` FROM users WHERE username = $1`, username,
+	).Scan(
+		&u.ID, &u.Username, &u.Email, &u.PasswordHash,
+		&u.AvatarURL, &u.Status, &u.Description, &u.IsAdmin,
+		&u.Plan, &u.LastActiveAt, &u.TotalTimeSeconds,
+		&u.CreatedAt, &u.UpdatedAt,
+	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			logger.Error(ctx, "repo.users.GetByUsername", "error", domain.ErrNotFound, "duration", time.Since(start), "username", username)
@@ -219,14 +233,14 @@ func (r *UserRepo) ListAll(ctx context.Context, limit, offset int, search string
 	var err error
 	if search != "" {
 		rows, err = r.db.QueryContext(ctx,
-			`SELECT id, username, email, password_hash, avatar_url, status, description, is_admin, created_at, updated_at
+			`SELECT `+userColumns+`
 			 FROM users WHERE username ILIKE '%' || $1 || '%' OR email ILIKE '%' || $1 || '%'
 			 ORDER BY id DESC LIMIT $2 OFFSET $3`,
 			search, limit, offset,
 		)
 	} else {
 		rows, err = r.db.QueryContext(ctx,
-			`SELECT id, username, email, password_hash, avatar_url, status, description, is_admin, created_at, updated_at
+			`SELECT `+userColumns+`
 			 FROM users ORDER BY id DESC LIMIT $1 OFFSET $2`,
 			limit, offset,
 		)
@@ -240,7 +254,12 @@ func (r *UserRepo) ListAll(ctx context.Context, limit, offset int, search string
 	var users []domain.User
 	for rows.Next() {
 		var u domain.User
-		if err := rows.Scan(&u.ID, &u.Username, &u.Email, &u.PasswordHash, &u.AvatarURL, &u.Status, &u.Description, &u.IsAdmin, &u.CreatedAt, &u.UpdatedAt); err != nil {
+		if err := rows.Scan(
+			&u.ID, &u.Username, &u.Email, &u.PasswordHash,
+			&u.AvatarURL, &u.Status, &u.Description, &u.IsAdmin,
+			&u.Plan, &u.LastActiveAt, &u.TotalTimeSeconds,
+			&u.CreatedAt, &u.UpdatedAt,
+		); err != nil {
 			logger.Error(ctx, "repo.users.ListAll.scan", "error", err, "duration", time.Since(start))
 			return nil, 0, err
 		}
@@ -278,6 +297,97 @@ func (r *UserRepo) SetBanned(ctx context.Context, userID int64, banned bool) err
 		return domain.ErrNotFound
 	}
 	logger.Info(ctx, "repo.users.SetBanned", "duration", time.Since(start), "user_id", userID, "banned", banned)
+	return nil
+}
+
+func (r *UserRepo) CountAll(ctx context.Context) (int64, error) {
+	start := time.Now()
+	var count int64
+	err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users`).Scan(&count)
+	if err != nil {
+		logger.Error(ctx, "repo.users.CountAll", "error", err, "duration", time.Since(start))
+		return 0, err
+	}
+	logger.Info(ctx, "repo.users.CountAll", "duration", time.Since(start), "count", count)
+	return count, nil
+}
+
+func (r *UserRepo) UpdatePlan(ctx context.Context, userID int64, plan string) error {
+	start := time.Now()
+	isAdmin := plan == domain.PlanAdmin
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE users SET plan = $1, is_admin = $2 WHERE id = $3`,
+		plan, isAdmin, userID,
+	)
+	if err != nil {
+		logger.Error(ctx, "repo.users.UpdatePlan", "error", err, "duration", time.Since(start), "user_id", userID)
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		logger.Error(ctx, "repo.users.UpdatePlan", "error", err, "duration", time.Since(start), "user_id", userID)
+		return err
+	}
+	if n == 0 {
+		logger.Error(ctx, "repo.users.UpdatePlan", "error", domain.ErrNotFound, "duration", time.Since(start), "user_id", userID)
+		return domain.ErrNotFound
+	}
+	logger.Info(ctx, "repo.users.UpdatePlan", "duration", time.Since(start), "user_id", userID, "plan", plan)
+	return nil
+}
+
+func (r *UserRepo) UpdateLastActive(ctx context.Context, userID int64, t time.Time) error {
+	start := time.Now()
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE users SET last_active_at = $1 WHERE id = $2`,
+		t, userID,
+	)
+	if err != nil {
+		logger.Error(ctx, "repo.users.UpdateLastActive", "error", err, "duration", time.Since(start), "user_id", userID)
+		return err
+	}
+	logger.Info(ctx, "repo.users.UpdateLastActive", "duration", time.Since(start), "user_id", userID)
+	return nil
+}
+
+func (r *UserRepo) IncrementTotalTime(ctx context.Context, userID int64, seconds int64) error {
+	start := time.Now()
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE users SET total_time_seconds = total_time_seconds + $1 WHERE id = $2`,
+		seconds, userID,
+	)
+	if err != nil {
+		logger.Error(ctx, "repo.users.IncrementTotalTime", "error", err, "duration", time.Since(start), "user_id", userID)
+		return err
+	}
+	logger.Info(ctx, "repo.users.IncrementTotalTime", "duration", time.Since(start), "user_id", userID, "seconds", seconds)
+	return nil
+}
+
+func (r *UserRepo) AdminUpdateUser(ctx context.Context, userID int64, username, email string) error {
+	start := time.Now()
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE users SET username = $1, email = $2 WHERE id = $3`,
+		username, email, userID,
+	)
+	if err != nil {
+		if isUniqueViolation(err) {
+			logger.Error(ctx, "repo.users.AdminUpdateUser", "error", domain.ErrConflict, "duration", time.Since(start), "user_id", userID)
+			return domain.ErrConflict
+		}
+		logger.Error(ctx, "repo.users.AdminUpdateUser", "error", err, "duration", time.Since(start), "user_id", userID)
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		logger.Error(ctx, "repo.users.AdminUpdateUser", "error", err, "duration", time.Since(start), "user_id", userID)
+		return err
+	}
+	if n == 0 {
+		logger.Error(ctx, "repo.users.AdminUpdateUser", "error", domain.ErrNotFound, "duration", time.Since(start), "user_id", userID)
+		return domain.ErrNotFound
+	}
+	logger.Info(ctx, "repo.users.AdminUpdateUser", "duration", time.Since(start), "user_id", userID)
 	return nil
 }
 

--- a/internal/auth/repository/postgres/user_test.go
+++ b/internal/auth/repository/postgres/user_test.go
@@ -96,8 +96,9 @@ func TestUserRepo_GetByID_Success(t *testing.T) {
 	rows := sqlmock.NewRows([]string{
 		"id", "username", "email", "password_hash",
 		"avatar_url", "status", "description", "is_admin",
+		"plan", "last_active_at", "total_time_seconds",
 		"created_at", "updated_at",
-	}).AddRow(int64(1), "testuser", "test@example.com", "hashedpwd", "avatar.png", "active", "desc", false, now, now)
+	}).AddRow(int64(1), "testuser", "test@example.com", "hashedpwd", "avatar.png", "active", "desc", false, "free", now, int64(0), now, now)
 
 	mock.ExpectQuery("SELECT .+ FROM users WHERE id").
 		WithArgs(int64(1)).
@@ -161,8 +162,9 @@ func TestUserRepo_GetByEmail_Success(t *testing.T) {
 	rows := sqlmock.NewRows([]string{
 		"id", "username", "email", "password_hash",
 		"avatar_url", "status", "description", "is_admin",
+		"plan", "last_active_at", "total_time_seconds",
 		"created_at", "updated_at",
-	}).AddRow(int64(1), "testuser", "test@example.com", "hashedpwd", "", "", "", false, now, now)
+	}).AddRow(int64(1), "testuser", "test@example.com", "hashedpwd", "", "", "", false, "free", nil, int64(0), now, now)
 
 	mock.ExpectQuery("SELECT .+ FROM users WHERE email").
 		WithArgs("test@example.com").
@@ -472,10 +474,11 @@ func TestUserRepo_ListAll_Success(t *testing.T) {
 	dataRows := sqlmock.NewRows([]string{
 		"id", "username", "email", "password_hash",
 		"avatar_url", "status", "description", "is_admin",
+		"plan", "last_active_at", "total_time_seconds",
 		"created_at", "updated_at",
 	}).
-		AddRow(int64(1), "user1", "user1@example.com", "hash1", "", "", "", false, now, now).
-		AddRow(int64(2), "user2", "user2@example.com", "hash2", "", "", "", false, now, now)
+		AddRow(int64(1), "user1", "user1@example.com", "hash1", "", "", "", false, "free", nil, int64(0), now, now).
+		AddRow(int64(2), "user2", "user2@example.com", "hash2", "", "", "", false, "free", nil, int64(0), now, now)
 
 	mock.ExpectQuery("SELECT COUNT").
 		WillReturnRows(countRows)
@@ -533,9 +536,10 @@ func TestUserRepo_ListAll_WithSearch(t *testing.T) {
 	dataRows := sqlmock.NewRows([]string{
 		"id", "username", "email", "password_hash",
 		"avatar_url", "status", "description", "is_admin",
+		"plan", "last_active_at", "total_time_seconds",
 		"created_at", "updated_at",
 	}).
-		AddRow(int64(1), "searchuser", "search@example.com", "hash1", "", "", "", false, now, now)
+		AddRow(int64(1), "searchuser", "search@example.com", "hash1", "", "", "", false, "free", nil, int64(0), now, now)
 
 	mock.ExpectQuery("SELECT COUNT").
 		WithArgs("searchterm").
@@ -593,8 +597,9 @@ func TestUserRepo_GetByUsername_Success(t *testing.T) {
 	rows := sqlmock.NewRows([]string{
 		"id", "username", "email", "password_hash",
 		"avatar_url", "status", "description", "is_admin",
+		"plan", "last_active_at", "total_time_seconds",
 		"created_at", "updated_at",
-	}).AddRow(int64(1), "testuser", "test@example.com", "hashedpwd", "", "", "", false, now, now)
+	}).AddRow(int64(1), "testuser", "test@example.com", "hashedpwd", "", "", "", false, "free", nil, int64(0), now, now)
 
 	mock.ExpectQuery("SELECT .+ FROM users WHERE username").
 		WithArgs("testuser").
@@ -652,6 +657,7 @@ func TestUserRepo_ListAll_Empty(t *testing.T) {
 	dataRows := sqlmock.NewRows([]string{
 		"id", "username", "email", "password_hash",
 		"avatar_url", "status", "description", "is_admin",
+		"plan", "last_active_at", "total_time_seconds",
 		"created_at", "updated_at",
 	})
 

--- a/internal/auth/usecase/admin.go
+++ b/internal/auth/usecase/admin.go
@@ -2,11 +2,15 @@ package usecase
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/auth/repository"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
+	"golang.org/x/crypto/bcrypt"
 )
+
+const freeTimeLimitSeconds = 3 * 3600
 
 type AdminUsecase struct {
 	userRepo  repository.UserRepository
@@ -39,6 +43,15 @@ func (uc *AdminUsecase) SetBan(ctx context.Context, adminUserID, targetUserID in
 	if err := uc.checkAdmin(ctx, adminUserID); err != nil {
 		return err
 	}
+	if ban {
+		target, err := uc.userRepo.GetByID(ctx, targetUserID)
+		if err != nil {
+			return err
+		}
+		if target.Plan != domain.PlanFreeze {
+			return fmt.Errorf("%w: can only ban users with freeze plan", domain.ErrInvalidInput)
+		}
+	}
 	return uc.userRepo.SetBanned(ctx, targetUserID, ban)
 }
 
@@ -63,9 +76,67 @@ func (uc *AdminUsecase) GetStats(ctx context.Context, adminUserID int64) (*Platf
 	if err != nil {
 		return nil, err
 	}
+	totalUsers, err := uc.userRepo.CountAll(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	return &PlatformStats{
-		DAU: dau,
-		MAU: mau,
+		TotalUsers: totalUsers,
+		DAU:        dau,
+		MAU:        mau,
 	}, nil
+}
+
+func (uc *AdminUsecase) AdminUpdateUser(ctx context.Context, adminUserID, targetUserID int64, username, email string) (*domain.User, error) {
+	if err := uc.checkAdmin(ctx, adminUserID); err != nil {
+		return nil, err
+	}
+	if username == "" || email == "" {
+		return nil, fmt.Errorf("%w: username and email are required", domain.ErrInvalidInput)
+	}
+	if err := uc.userRepo.AdminUpdateUser(ctx, targetUserID, username, email); err != nil {
+		return nil, err
+	}
+	return uc.userRepo.GetByID(ctx, targetUserID)
+}
+
+func (uc *AdminUsecase) AdminResetPassword(ctx context.Context, adminUserID, targetUserID int64, newPassword string) error {
+	if err := uc.checkAdmin(ctx, adminUserID); err != nil {
+		return err
+	}
+	if len(newPassword) < 8 {
+		return fmt.Errorf("%w: password must be at least 8 characters", domain.ErrInvalidInput)
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	if err != nil {
+		return err
+	}
+	return uc.userRepo.UpdatePassword(ctx, targetUserID, string(hash))
+}
+
+func (uc *AdminUsecase) AdminSetPlan(ctx context.Context, adminUserID, targetUserID int64, plan string) error {
+	if err := uc.checkAdmin(ctx, adminUserID); err != nil {
+		return err
+	}
+	if !domain.ValidPlans[plan] {
+		return fmt.Errorf("%w: invalid plan: %s", domain.ErrInvalidInput, plan)
+	}
+	return uc.userRepo.UpdatePlan(ctx, targetUserID, plan)
+}
+
+func (uc *AdminUsecase) GetActivityStats(ctx context.Context, adminUserID int64, dauDays, mauMonths int) ([]domain.DayCount, []domain.MonthCount, error) {
+	if err := uc.checkAdmin(ctx, adminUserID); err != nil {
+		return nil, nil, err
+	}
+	now := time.Now()
+	dau, err := uc.eventRepo.CountActiveUsersByDay(ctx, now.AddDate(0, 0, -dauDays))
+	if err != nil {
+		return nil, nil, err
+	}
+	mau, err := uc.eventRepo.CountActiveUsersByMonth(ctx, now.AddDate(0, -mauMonths, 0))
+	if err != nil {
+		return nil, nil, err
+	}
+	return dau, mau, nil
 }

--- a/internal/auth/usecase/admin_test.go
+++ b/internal/auth/usecase/admin_test.go
@@ -61,9 +61,11 @@ func TestAdminUsecase_SetBan_Success(t *testing.T) {
 	eventRepo := mocks.NewMockEventRepository(ctrl)
 
 	adminUser := &domain.User{ID: 1, Username: "admin", IsAdmin: true}
+	targetUser := &domain.User{ID: 2, Username: "user", Plan: domain.PlanFreeze}
 
 	gomock.InOrder(
 		userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(adminUser, nil),
+		userRepo.EXPECT().GetByID(gomock.Any(), int64(2)).Return(targetUser, nil),
 		userRepo.EXPECT().SetBanned(gomock.Any(), int64(2), true).Return(nil),
 	)
 
@@ -106,6 +108,7 @@ func TestAdminUsecase_GetStats_Success(t *testing.T) {
 		userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(adminUser, nil),
 		eventRepo.EXPECT().CountActiveUsers(gomock.Any(), gomock.Any()).Return(int64(100), nil),
 		eventRepo.EXPECT().CountActiveUsers(gomock.Any(), gomock.Any()).Return(int64(500), nil),
+		userRepo.EXPECT().CountAll(gomock.Any()).Return(int64(42), nil),
 	)
 
 	uc := NewAdminUsecase(userRepo, eventRepo)
@@ -117,6 +120,9 @@ func TestAdminUsecase_GetStats_Success(t *testing.T) {
 	if stats.DAU != 100 || stats.MAU != 500 {
 		t.Fatalf("unexpected stats: DAU=%d, MAU=%d", stats.DAU, stats.MAU)
 	}
+	if stats.TotalUsers != 42 {
+		t.Fatalf("expected TotalUsers=42, got %d", stats.TotalUsers)
+	}
 }
 
 func TestEventUsecase_Track_Success(t *testing.T) {
@@ -126,7 +132,8 @@ func TestEventUsecase_Track_Success(t *testing.T) {
 	eventRepo := mocks.NewMockEventRepository(ctrl)
 	eventRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
 
-	uc := NewEventUsecase(eventRepo)
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	uc := NewEventUsecase(eventRepo, userRepo)
 	err := uc.Track(context.Background(), 1, "login", "{}")
 
 	if err != nil {
@@ -141,10 +148,216 @@ func TestEventUsecase_Track_EmptyMetadata(t *testing.T) {
 	eventRepo := mocks.NewMockEventRepository(ctrl)
 	eventRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
 
-	uc := NewEventUsecase(eventRepo)
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	uc := NewEventUsecase(eventRepo, userRepo)
 	err := uc.Track(context.Background(), 1, "logout", "")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAdminUsecase_AdminUpdateUser_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+
+	adminUser := &domain.User{ID: 1, IsAdmin: true}
+	updatedUser := &domain.User{ID: 2, Username: "newname", Email: "new@mail.com"}
+
+	gomock.InOrder(
+		userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(adminUser, nil),
+		userRepo.EXPECT().AdminUpdateUser(gomock.Any(), int64(2), "newname", "new@mail.com").Return(nil),
+		userRepo.EXPECT().GetByID(gomock.Any(), int64(2)).Return(updatedUser, nil),
+	)
+
+	uc := NewAdminUsecase(userRepo, eventRepo)
+	user, err := uc.AdminUpdateUser(context.Background(), 1, 2, "newname", "new@mail.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user.Username != "newname" {
+		t.Fatalf("expected newname, got %s", user.Username)
+	}
+}
+
+func TestAdminUsecase_AdminSetPlan_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+
+	adminUser := &domain.User{ID: 1, IsAdmin: true}
+	gomock.InOrder(
+		userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(adminUser, nil),
+		userRepo.EXPECT().UpdatePlan(gomock.Any(), int64(2), "pro").Return(nil),
+	)
+
+	uc := NewAdminUsecase(userRepo, eventRepo)
+	err := uc.AdminSetPlan(context.Background(), 1, 2, "pro")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAdminUsecase_AdminSetPlan_InvalidPlan(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+
+	adminUser := &domain.User{ID: 1, IsAdmin: true}
+	userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(adminUser, nil)
+
+	uc := NewAdminUsecase(userRepo, eventRepo)
+	err := uc.AdminSetPlan(context.Background(), 1, 2, "invalid")
+	if err == nil {
+		t.Fatal("expected error for invalid plan")
+	}
+}
+
+func TestAdminUsecase_SetBan_OnlyFreezeAllowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+
+	adminUser := &domain.User{ID: 1, IsAdmin: true}
+	targetUser := &domain.User{ID: 2, Plan: domain.PlanFree}
+
+	gomock.InOrder(
+		userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(adminUser, nil),
+		userRepo.EXPECT().GetByID(gomock.Any(), int64(2)).Return(targetUser, nil),
+	)
+
+	uc := NewAdminUsecase(userRepo, eventRepo)
+	err := uc.SetBan(context.Background(), 1, 2, true)
+	if err == nil {
+		t.Fatal("expected error when banning non-freeze user")
+	}
+}
+
+func TestEventUsecase_Track_Heartbeat_UpdatesActivity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+	userRepo := mocks.NewMockUserRepository(ctrl)
+
+	eventRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
+	userRepo.EXPECT().UpdateLastActive(gomock.Any(), int64(1), gomock.Any()).Return(nil)
+	userRepo.EXPECT().IncrementTotalTime(gomock.Any(), int64(1), int64(60)).Return(nil)
+	userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(&domain.User{ID: 1, Plan: domain.PlanPro, TotalTimeSeconds: 100}, nil)
+
+	uc := NewEventUsecase(eventRepo, userRepo)
+	err := uc.Track(context.Background(), 1, "heartbeat", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAdminUsecase_AdminResetPassword_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+
+	adminUser := &domain.User{ID: 1, IsAdmin: true}
+	gomock.InOrder(
+		userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(adminUser, nil),
+		userRepo.EXPECT().UpdatePassword(gomock.Any(), int64(2), gomock.Any()).Return(nil),
+	)
+
+	uc := NewAdminUsecase(userRepo, eventRepo)
+	err := uc.AdminResetPassword(context.Background(), 1, 2, "newpassword123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAdminUsecase_AdminResetPassword_TooShort(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+
+	adminUser := &domain.User{ID: 1, IsAdmin: true}
+	userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(adminUser, nil)
+
+	uc := NewAdminUsecase(userRepo, eventRepo)
+	err := uc.AdminResetPassword(context.Background(), 1, 2, "short")
+	if err == nil {
+		t.Fatal("expected error for short password")
+	}
+}
+
+func TestAdminUsecase_AdminUpdateUser_EmptyFields(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+
+	adminUser := &domain.User{ID: 1, IsAdmin: true}
+	userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(adminUser, nil)
+
+	uc := NewAdminUsecase(userRepo, eventRepo)
+	_, err := uc.AdminUpdateUser(context.Background(), 1, 2, "", "")
+	if err == nil {
+		t.Fatal("expected error for empty fields")
+	}
+}
+
+func TestEventUsecase_Track_Heartbeat_AutoFreeze(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+	userRepo := mocks.NewMockUserRepository(ctrl)
+
+	eventRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
+	userRepo.EXPECT().UpdateLastActive(gomock.Any(), int64(1), gomock.Any()).Return(nil)
+	userRepo.EXPECT().IncrementTotalTime(gomock.Any(), int64(1), int64(60)).Return(nil)
+	userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(&domain.User{
+		ID: 1, Plan: domain.PlanFree, TotalTimeSeconds: freeTimeLimitSeconds - 30,
+	}, nil)
+	userRepo.EXPECT().UpdatePlan(gomock.Any(), int64(1), domain.PlanFreeze).Return(nil)
+
+	uc := NewEventUsecase(eventRepo, userRepo)
+	err := uc.Track(context.Background(), 1, "heartbeat", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAdminUsecase_GetActivityStats_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+
+	adminUser := &domain.User{ID: 1, IsAdmin: true}
+	userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(adminUser, nil)
+	eventRepo.EXPECT().CountActiveUsersByDay(gomock.Any(), gomock.Any()).Return([]domain.DayCount{{Count: 5}}, nil)
+	eventRepo.EXPECT().CountActiveUsersByMonth(gomock.Any(), gomock.Any()).Return([]domain.MonthCount{{Count: 50}}, nil)
+
+	uc := NewAdminUsecase(userRepo, eventRepo)
+	dau, mau, err := uc.GetActivityStats(context.Background(), 1, 30, 12)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dau) != 1 || dau[0].Count != 5 {
+		t.Fatalf("unexpected dau: %v", dau)
+	}
+	if len(mau) != 1 || mau[0].Count != 50 {
+		t.Fatalf("unexpected mau: %v", mau)
 	}
 }

--- a/internal/auth/usecase/event.go
+++ b/internal/auth/usecase/event.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/auth/repository"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
@@ -10,10 +11,11 @@ import (
 
 type EventUsecase struct {
 	eventRepo repository.EventRepository
+	userRepo  repository.UserRepository
 }
 
-func NewEventUsecase(eventRepo repository.EventRepository) *EventUsecase {
-	return &EventUsecase{eventRepo: eventRepo}
+func NewEventUsecase(eventRepo repository.EventRepository, userRepo repository.UserRepository) *EventUsecase {
+	return &EventUsecase{eventRepo: eventRepo, userRepo: userRepo}
 }
 
 func (uc *EventUsecase) Track(ctx context.Context, userID int64, eventType string, metadataJSON string) error {
@@ -29,5 +31,20 @@ func (uc *EventUsecase) Track(ctx context.Context, userID int64, eventType strin
 		EventType: eventType,
 		Metadata:  metadata,
 	}
-	return uc.eventRepo.Create(ctx, event)
+	if err := uc.eventRepo.Create(ctx, event); err != nil {
+		return err
+	}
+
+	if eventType == "heartbeat" {
+		now := time.Now()
+		_ = uc.userRepo.UpdateLastActive(ctx, userID, now)
+		_ = uc.userRepo.IncrementTotalTime(ctx, userID, 60)
+
+		user, err := uc.userRepo.GetByID(ctx, userID)
+		if err == nil && user.Plan == domain.PlanFree && user.TotalTimeSeconds+60 >= freeTimeLimitSeconds {
+			_ = uc.userRepo.UpdatePlan(ctx, userID, domain.PlanFreeze)
+		}
+	}
+
+	return nil
 }

--- a/internal/domain/event.go
+++ b/internal/domain/event.go
@@ -12,3 +12,13 @@ type UserEvent struct {
 	Metadata  json.RawMessage
 	CreatedAt time.Time
 }
+
+type DayCount struct {
+	Date  time.Time
+	Count int64
+}
+
+type MonthCount struct {
+	Month time.Time
+	Count int64
+}

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -2,15 +2,34 @@ package domain
 
 import "time"
 
+const (
+	PlanFree   = "free"
+	PlanFreeze = "freeze"
+	PlanPro    = "pro"
+	PlanMax    = "max"
+	PlanAdmin  = "admin"
+)
+
+var ValidPlans = map[string]bool{
+	PlanFree:   true,
+	PlanFreeze: true,
+	PlanPro:    true,
+	PlanMax:    true,
+	PlanAdmin:  true,
+}
+
 type User struct {
-	ID           int64
-	Username     string
-	Email        string
-	PasswordHash string
-	AvatarURL    string
-	Status       string
-	Description  string
-	IsAdmin      bool
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	ID               int64
+	Username         string
+	Email            string
+	PasswordHash     string
+	AvatarURL        string
+	Status           string
+	Description      string
+	IsAdmin          bool
+	Plan             string
+	LastActiveAt     *time.Time
+	TotalTimeSeconds int64
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
 }

--- a/internal/gateway/handler/admin_handler.go
+++ b/internal/gateway/handler/admin_handler.go
@@ -29,9 +29,13 @@ func (h *AdminHandler) RegisterRoutes(mux *http.ServeMux, authMw, adminMw middle
 	mux.Handle("GET /api/v1/admin/users", chain(h.ListUsers))
 	mux.Handle("POST /api/v1/admin/users/{id}/ban", chain(h.BanUser))
 	mux.Handle("POST /api/v1/admin/users/{id}/unban", chain(h.UnbanUser))
+	mux.Handle("PUT /api/v1/admin/users/{id}", chain(h.UpdateUser))
+	mux.Handle("PUT /api/v1/admin/users/{id}/password", chain(h.ResetPassword))
+	mux.Handle("PUT /api/v1/admin/users/{id}/plan", chain(h.SetPlan))
 	mux.Handle("GET /api/v1/admin/notebooks", chain(h.ListNotebooks))
 	mux.Handle("DELETE /api/v1/admin/notebooks/{id}", chain(h.DeleteNotebook))
 	mux.Handle("GET /api/v1/admin/stats", chain(h.GetStats))
+	mux.Handle("GET /api/v1/admin/stats/activity", chain(h.GetActivityStats))
 }
 
 func (h *AdminHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
@@ -79,6 +83,11 @@ func (h *AdminHandler) BanUser(w http.ResponseWriter, r *http.Request) {
 		httputil.MapDomainError(w, grpcutil.GRPCToDomainError(err))
 		return
 	}
+
+	_, _ = h.notebookClient.AdminSetUserNotebooksPrivate(r.Context(), &pbnotebook.AdminSetUserNotebooksPrivateRequest{
+		OwnerId: targetID,
+	})
+
 	httputil.JSON(w, http.StatusOK, nil)
 }
 
@@ -94,6 +103,92 @@ func (h *AdminHandler) UnbanUser(w http.ResponseWriter, r *http.Request) {
 		AdminUserId:  user.ID,
 		TargetUserId: targetID,
 		Ban:          false,
+	})
+	if err != nil {
+		httputil.MapDomainError(w, grpcutil.GRPCToDomainError(err))
+		return
+	}
+	httputil.JSON(w, http.StatusOK, nil)
+}
+
+func (h *AdminHandler) UpdateUser(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	targetID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		httputil.Error(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+
+	var req struct {
+		Username string `json:"username"`
+		Email    string `json:"email"`
+	}
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	resp, err := h.authClient.AdminUpdateUser(r.Context(), &pbauth.AdminUpdateUserRequest{
+		AdminUserId:  user.ID,
+		TargetUserId: targetID,
+		Username:     req.Username,
+		Email:        req.Email,
+	})
+	if err != nil {
+		httputil.MapDomainError(w, grpcutil.GRPCToDomainError(err))
+		return
+	}
+	httputil.JSON(w, http.StatusOK, protoUserToDTO(resp.GetUser()))
+}
+
+func (h *AdminHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	targetID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		httputil.Error(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+
+	var req struct {
+		Password string `json:"password"`
+	}
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	_, err = h.authClient.AdminResetPassword(r.Context(), &pbauth.AdminResetPasswordRequest{
+		AdminUserId:  user.ID,
+		TargetUserId: targetID,
+		NewPassword:  req.Password,
+	})
+	if err != nil {
+		httputil.MapDomainError(w, grpcutil.GRPCToDomainError(err))
+		return
+	}
+	httputil.JSON(w, http.StatusOK, nil)
+}
+
+func (h *AdminHandler) SetPlan(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	targetID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		httputil.Error(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+
+	var req struct {
+		Plan string `json:"plan"`
+	}
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	_, err = h.authClient.AdminSetPlan(r.Context(), &pbauth.AdminSetPlanRequest{
+		AdminUserId:  user.ID,
+		TargetUserId: targetID,
+		Plan:         req.Plan,
 	})
 	if err != nil {
 		httputil.MapDomainError(w, grpcutil.GRPCToDomainError(err))
@@ -170,10 +265,57 @@ func (h *AdminHandler) GetStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	nbResp, nbErr := h.notebookClient.AdminGetNotebookCount(r.Context(), &pbnotebook.AdminGetNotebookCountRequest{})
+	var totalNotebooks int64
+	if nbErr == nil {
+		totalNotebooks = nbResp.GetTotal()
+	}
+
 	httputil.JSON(w, http.StatusOK, map[string]interface{}{
-		"total_users":    resp.GetTotalUsers(),
-		"total_sessions": resp.GetTotalSessions(),
-		"dau":            resp.GetDau(),
-		"mau":            resp.GetMau(),
+		"total_users":     resp.GetTotalUsers(),
+		"total_sessions":  resp.GetTotalSessions(),
+		"dau":             resp.GetDau(),
+		"mau":             resp.GetMau(),
+		"total_notebooks": totalNotebooks,
+	})
+}
+
+func (h *AdminHandler) GetActivityStats(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+
+	dauDays, _ := strconv.Atoi(r.URL.Query().Get("dau_days"))
+	mauMonths, _ := strconv.Atoi(r.URL.Query().Get("mau_months"))
+
+	resp, err := h.authClient.AdminGetActivityStats(r.Context(), &pbauth.AdminGetActivityStatsRequest{
+		AdminUserId: user.ID,
+		DauDays:     int32(dauDays),   //nolint:gosec
+		MauMonths:   int32(mauMonths), //nolint:gosec
+	})
+	if err != nil {
+		httputil.MapDomainError(w, grpcutil.GRPCToDomainError(err))
+		return
+	}
+
+	type dauItem struct {
+		Date  string `json:"date"`
+		Count int64  `json:"count"`
+	}
+	type mauItem struct {
+		Month string `json:"month"`
+		Count int64  `json:"count"`
+	}
+
+	dau := make([]dauItem, len(resp.GetDau()))
+	for i, d := range resp.GetDau() {
+		dau[i] = dauItem{Date: d.GetDate(), Count: d.GetCount()}
+	}
+	mau := make([]mauItem, len(resp.GetMau()))
+	for i, m := range resp.GetMau() {
+		mau[i] = mauItem{Month: m.GetMonth(), Count: m.GetCount()}
+	}
+
+	httputil.JSON(w, http.StatusOK, map[string]interface{}{
+		"dau": dau,
+		"mau": mau,
 	})
 }

--- a/internal/gateway/handler/admin_handler_test.go
+++ b/internal/gateway/handler/admin_handler_test.go
@@ -60,11 +60,14 @@ func TestAdminHandler_ListUsers_GRPCError(t *testing.T) {
 func TestAdminHandler_BanUser_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	authClient := mocks.NewMockAuthServiceClient(ctrl)
+	nbClient := mocks.NewMockNotebookServiceClient(ctrl)
 
 	authClient.EXPECT().AdminSetBan(gomock.Any(), gomock.Any()).
 		Return(&pbauth.AdminSetBanResponse{}, nil)
+	nbClient.EXPECT().AdminSetUserNotebooksPrivate(gomock.Any(), gomock.Any()).
+		Return(&pbnotebook.AdminSetUserNotebooksPrivateResponse{}, nil)
 
-	h := NewAdminHandler(authClient, nil)
+	h := NewAdminHandler(authClient, nbClient)
 	req := httptest.NewRequest("POST", "/api/v1/admin/users/2/ban", nil)
 	req.SetPathValue("id", "2")
 	req = withUser(req, 1)
@@ -239,6 +242,7 @@ func TestAdminHandler_DeleteNotebook_GRPCError(t *testing.T) {
 func TestAdminHandler_GetStats_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	authClient := mocks.NewMockAuthServiceClient(ctrl)
+	nbClient := mocks.NewMockNotebookServiceClient(ctrl)
 
 	authClient.EXPECT().AdminGetStats(gomock.Any(), gomock.Any()).Return(&pbauth.AdminGetStatsResponse{
 		TotalUsers:    100,
@@ -246,8 +250,10 @@ func TestAdminHandler_GetStats_Success(t *testing.T) {
 		Dau:           10,
 		Mau:           30,
 	}, nil)
+	nbClient.EXPECT().AdminGetNotebookCount(gomock.Any(), gomock.Any()).
+		Return(&pbnotebook.AdminGetNotebookCountResponse{Total: 25}, nil)
 
-	h := NewAdminHandler(authClient, nil)
+	h := NewAdminHandler(authClient, nbClient)
 	req := httptest.NewRequest("GET", "/api/v1/admin/stats", nil)
 	req = withUser(req, 1)
 	rec := httptest.NewRecorder()

--- a/internal/gateway/handler/auth_handler.go
+++ b/internal/gateway/handler/auth_handler.go
@@ -135,15 +135,22 @@ func clearSessionCookie(w http.ResponseWriter) {
 }
 
 func protoUserToDTO(info *pb.UserInfo) dto.UserResponse {
-	return dto.UserResponse{
-		ID:          info.GetId(),
-		Username:    info.GetUsername(),
-		Email:       info.GetEmail(),
-		AvatarURL:   info.GetAvatarUrl(),
-		Status:      info.GetStatus(),
-		Description: info.GetDescription(),
-		IsAdmin:     info.GetIsAdmin(),
-		CreatedAt:   time.Unix(info.GetCreatedAt(), 0),
-		UpdatedAt:   time.Unix(info.GetUpdatedAt(), 0),
+	resp := dto.UserResponse{
+		ID:               info.GetId(),
+		Username:         info.GetUsername(),
+		Email:            info.GetEmail(),
+		AvatarURL:        info.GetAvatarUrl(),
+		Status:           info.GetStatus(),
+		Description:      info.GetDescription(),
+		IsAdmin:          info.GetIsAdmin(),
+		Plan:             info.GetPlan(),
+		TotalTimeSeconds: info.GetTotalTimeSeconds(),
+		CreatedAt:        time.Unix(info.GetCreatedAt(), 0),
+		UpdatedAt:        time.Unix(info.GetUpdatedAt(), 0),
 	}
+	if info.GetLastActiveAt() != 0 {
+		t := time.Unix(info.GetLastActiveAt(), 0)
+		resp.LastActiveAt = &t
+	}
+	return resp
 }

--- a/internal/mocks/auth_grpc_client_mock.go
+++ b/internal/mocks/auth_grpc_client_mock.go
@@ -42,6 +42,26 @@ func (m *MockAuthServiceClient) EXPECT() *MockAuthServiceClientMockRecorder {
 	return m.recorder
 }
 
+// AdminGetActivityStats mocks base method.
+func (m *MockAuthServiceClient) AdminGetActivityStats(ctx context.Context, in *auth.AdminGetActivityStatsRequest, opts ...grpc.CallOption) (*auth.AdminGetActivityStatsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AdminGetActivityStats", varargs...)
+	ret0, _ := ret[0].(*auth.AdminGetActivityStatsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AdminGetActivityStats indicates an expected call of AdminGetActivityStats.
+func (mr *MockAuthServiceClientMockRecorder) AdminGetActivityStats(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminGetActivityStats", reflect.TypeOf((*MockAuthServiceClient)(nil).AdminGetActivityStats), varargs...)
+}
+
 // AdminGetStats mocks base method.
 func (m *MockAuthServiceClient) AdminGetStats(ctx context.Context, in *auth.AdminGetStatsRequest, opts ...grpc.CallOption) (*auth.AdminGetStatsResponse, error) {
 	m.ctrl.T.Helper()
@@ -82,6 +102,26 @@ func (mr *MockAuthServiceClientMockRecorder) AdminListUsers(ctx, in any, opts ..
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminListUsers", reflect.TypeOf((*MockAuthServiceClient)(nil).AdminListUsers), varargs...)
 }
 
+// AdminResetPassword mocks base method.
+func (m *MockAuthServiceClient) AdminResetPassword(ctx context.Context, in *auth.AdminResetPasswordRequest, opts ...grpc.CallOption) (*auth.AdminResetPasswordResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AdminResetPassword", varargs...)
+	ret0, _ := ret[0].(*auth.AdminResetPasswordResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AdminResetPassword indicates an expected call of AdminResetPassword.
+func (mr *MockAuthServiceClientMockRecorder) AdminResetPassword(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminResetPassword", reflect.TypeOf((*MockAuthServiceClient)(nil).AdminResetPassword), varargs...)
+}
+
 // AdminSetBan mocks base method.
 func (m *MockAuthServiceClient) AdminSetBan(ctx context.Context, in *auth.AdminSetBanRequest, opts ...grpc.CallOption) (*auth.AdminSetBanResponse, error) {
 	m.ctrl.T.Helper()
@@ -100,6 +140,46 @@ func (mr *MockAuthServiceClientMockRecorder) AdminSetBan(ctx, in any, opts ...an
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminSetBan", reflect.TypeOf((*MockAuthServiceClient)(nil).AdminSetBan), varargs...)
+}
+
+// AdminSetPlan mocks base method.
+func (m *MockAuthServiceClient) AdminSetPlan(ctx context.Context, in *auth.AdminSetPlanRequest, opts ...grpc.CallOption) (*auth.AdminSetPlanResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AdminSetPlan", varargs...)
+	ret0, _ := ret[0].(*auth.AdminSetPlanResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AdminSetPlan indicates an expected call of AdminSetPlan.
+func (mr *MockAuthServiceClientMockRecorder) AdminSetPlan(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminSetPlan", reflect.TypeOf((*MockAuthServiceClient)(nil).AdminSetPlan), varargs...)
+}
+
+// AdminUpdateUser mocks base method.
+func (m *MockAuthServiceClient) AdminUpdateUser(ctx context.Context, in *auth.AdminUpdateUserRequest, opts ...grpc.CallOption) (*auth.UserResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AdminUpdateUser", varargs...)
+	ret0, _ := ret[0].(*auth.UserResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AdminUpdateUser indicates an expected call of AdminUpdateUser.
+func (mr *MockAuthServiceClientMockRecorder) AdminUpdateUser(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminUpdateUser", reflect.TypeOf((*MockAuthServiceClient)(nil).AdminUpdateUser), varargs...)
 }
 
 // ChangeEmail mocks base method.

--- a/internal/mocks/auth_repo_mock.go
+++ b/internal/mocks/auth_repo_mock.go
@@ -42,6 +42,35 @@ func (m *MockUserRepository) EXPECT() *MockUserRepositoryMockRecorder {
 	return m.recorder
 }
 
+// AdminUpdateUser mocks base method.
+func (m *MockUserRepository) AdminUpdateUser(ctx context.Context, userID int64, username, email string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AdminUpdateUser", ctx, userID, username, email)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AdminUpdateUser indicates an expected call of AdminUpdateUser.
+func (mr *MockUserRepositoryMockRecorder) AdminUpdateUser(ctx, userID, username, email any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminUpdateUser", reflect.TypeOf((*MockUserRepository)(nil).AdminUpdateUser), ctx, userID, username, email)
+}
+
+// CountAll mocks base method.
+func (m *MockUserRepository) CountAll(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountAll", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountAll indicates an expected call of CountAll.
+func (mr *MockUserRepositoryMockRecorder) CountAll(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountAll", reflect.TypeOf((*MockUserRepository)(nil).CountAll), ctx)
+}
+
 // Create mocks base method.
 func (m *MockUserRepository) Create(ctx context.Context, user *domain.User) (int64, error) {
 	m.ctrl.T.Helper()
@@ -102,6 +131,20 @@ func (mr *MockUserRepositoryMockRecorder) GetByUsername(ctx, username any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByUsername", reflect.TypeOf((*MockUserRepository)(nil).GetByUsername), ctx, username)
 }
 
+// IncrementTotalTime mocks base method.
+func (m *MockUserRepository) IncrementTotalTime(ctx context.Context, userID, seconds int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IncrementTotalTime", ctx, userID, seconds)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IncrementTotalTime indicates an expected call of IncrementTotalTime.
+func (mr *MockUserRepositoryMockRecorder) IncrementTotalTime(ctx, userID, seconds any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncrementTotalTime", reflect.TypeOf((*MockUserRepository)(nil).IncrementTotalTime), ctx, userID, seconds)
+}
+
 // ListAll mocks base method.
 func (m *MockUserRepository) ListAll(ctx context.Context, limit, offset int, search string) ([]domain.User, int, error) {
 	m.ctrl.T.Helper()
@@ -160,6 +203,20 @@ func (mr *MockUserRepositoryMockRecorder) UpdateEmail(ctx, userID, email any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEmail", reflect.TypeOf((*MockUserRepository)(nil).UpdateEmail), ctx, userID, email)
 }
 
+// UpdateLastActive mocks base method.
+func (m *MockUserRepository) UpdateLastActive(ctx context.Context, userID int64, t time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateLastActive", ctx, userID, t)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateLastActive indicates an expected call of UpdateLastActive.
+func (mr *MockUserRepositoryMockRecorder) UpdateLastActive(ctx, userID, t any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLastActive", reflect.TypeOf((*MockUserRepository)(nil).UpdateLastActive), ctx, userID, t)
+}
+
 // UpdatePassword mocks base method.
 func (m *MockUserRepository) UpdatePassword(ctx context.Context, userID int64, passwordHash string) error {
 	m.ctrl.T.Helper()
@@ -172,6 +229,20 @@ func (m *MockUserRepository) UpdatePassword(ctx context.Context, userID int64, p
 func (mr *MockUserRepositoryMockRecorder) UpdatePassword(ctx, userID, passwordHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePassword", reflect.TypeOf((*MockUserRepository)(nil).UpdatePassword), ctx, userID, passwordHash)
+}
+
+// UpdatePlan mocks base method.
+func (m *MockUserRepository) UpdatePlan(ctx context.Context, userID int64, plan string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdatePlan", ctx, userID, plan)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdatePlan indicates an expected call of UpdatePlan.
+func (mr *MockUserRepositoryMockRecorder) UpdatePlan(ctx, userID, plan any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePlan", reflect.TypeOf((*MockUserRepository)(nil).UpdatePlan), ctx, userID, plan)
 }
 
 // UpdateProfile mocks base method.
@@ -292,6 +363,36 @@ func (m *MockEventRepository) CountActiveUsers(ctx context.Context, since time.T
 func (mr *MockEventRepositoryMockRecorder) CountActiveUsers(ctx, since any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountActiveUsers", reflect.TypeOf((*MockEventRepository)(nil).CountActiveUsers), ctx, since)
+}
+
+// CountActiveUsersByDay mocks base method.
+func (m *MockEventRepository) CountActiveUsersByDay(ctx context.Context, since time.Time) ([]domain.DayCount, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountActiveUsersByDay", ctx, since)
+	ret0, _ := ret[0].([]domain.DayCount)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountActiveUsersByDay indicates an expected call of CountActiveUsersByDay.
+func (mr *MockEventRepositoryMockRecorder) CountActiveUsersByDay(ctx, since any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountActiveUsersByDay", reflect.TypeOf((*MockEventRepository)(nil).CountActiveUsersByDay), ctx, since)
+}
+
+// CountActiveUsersByMonth mocks base method.
+func (m *MockEventRepository) CountActiveUsersByMonth(ctx context.Context, since time.Time) ([]domain.MonthCount, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountActiveUsersByMonth", ctx, since)
+	ret0, _ := ret[0].([]domain.MonthCount)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountActiveUsersByMonth indicates an expected call of CountActiveUsersByMonth.
+func (mr *MockEventRepositoryMockRecorder) CountActiveUsersByMonth(ctx, since any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountActiveUsersByMonth", reflect.TypeOf((*MockEventRepository)(nil).CountActiveUsersByMonth), ctx, since)
 }
 
 // Create mocks base method.

--- a/internal/mocks/notebook_grpc_client_mock.go
+++ b/internal/mocks/notebook_grpc_client_mock.go
@@ -82,6 +82,26 @@ func (mr *MockNotebookServiceClientMockRecorder) AdminDeleteNotebook(ctx, in any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminDeleteNotebook", reflect.TypeOf((*MockNotebookServiceClient)(nil).AdminDeleteNotebook), varargs...)
 }
 
+// AdminGetNotebookCount mocks base method.
+func (m *MockNotebookServiceClient) AdminGetNotebookCount(ctx context.Context, in *notebook.AdminGetNotebookCountRequest, opts ...grpc.CallOption) (*notebook.AdminGetNotebookCountResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AdminGetNotebookCount", varargs...)
+	ret0, _ := ret[0].(*notebook.AdminGetNotebookCountResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AdminGetNotebookCount indicates an expected call of AdminGetNotebookCount.
+func (mr *MockNotebookServiceClientMockRecorder) AdminGetNotebookCount(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminGetNotebookCount", reflect.TypeOf((*MockNotebookServiceClient)(nil).AdminGetNotebookCount), varargs...)
+}
+
 // AdminListNotebooks mocks base method.
 func (m *MockNotebookServiceClient) AdminListNotebooks(ctx context.Context, in *notebook.AdminListNotebooksRequest, opts ...grpc.CallOption) (*notebook.AdminListNotebooksResponse, error) {
 	m.ctrl.T.Helper()
@@ -100,6 +120,26 @@ func (mr *MockNotebookServiceClientMockRecorder) AdminListNotebooks(ctx, in any,
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminListNotebooks", reflect.TypeOf((*MockNotebookServiceClient)(nil).AdminListNotebooks), varargs...)
+}
+
+// AdminSetUserNotebooksPrivate mocks base method.
+func (m *MockNotebookServiceClient) AdminSetUserNotebooksPrivate(ctx context.Context, in *notebook.AdminSetUserNotebooksPrivateRequest, opts ...grpc.CallOption) (*notebook.AdminSetUserNotebooksPrivateResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AdminSetUserNotebooksPrivate", varargs...)
+	ret0, _ := ret[0].(*notebook.AdminSetUserNotebooksPrivateResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AdminSetUserNotebooksPrivate indicates an expected call of AdminSetUserNotebooksPrivate.
+func (mr *MockNotebookServiceClientMockRecorder) AdminSetUserNotebooksPrivate(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminSetUserNotebooksPrivate", reflect.TypeOf((*MockNotebookServiceClient)(nil).AdminSetUserNotebooksPrivate), varargs...)
 }
 
 // Create mocks base method.

--- a/internal/mocks/notebook_repo_mock.go
+++ b/internal/mocks/notebook_repo_mock.go
@@ -175,6 +175,20 @@ func (mr *MockNotebookRepositoryMockRecorder) ListAll(ctx, limit, offset, search
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAll", reflect.TypeOf((*MockNotebookRepository)(nil).ListAll), ctx, limit, offset, search)
 }
 
+// SetAllPrivateByOwner mocks base method.
+func (m *MockNotebookRepository) SetAllPrivateByOwner(ctx context.Context, ownerID int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetAllPrivateByOwner", ctx, ownerID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetAllPrivateByOwner indicates an expected call of SetAllPrivateByOwner.
+func (mr *MockNotebookRepositoryMockRecorder) SetAllPrivateByOwner(ctx, ownerID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAllPrivateByOwner", reflect.TypeOf((*MockNotebookRepository)(nil).SetAllPrivateByOwner), ctx, ownerID)
+}
+
 // Update mocks base method.
 func (m *MockNotebookRepository) Update(ctx context.Context, notebook *domain.Notebook) error {
 	m.ctrl.T.Helper()

--- a/internal/notebook/grpc/server.go
+++ b/internal/notebook/grpc/server.go
@@ -142,6 +142,21 @@ func (s *Server) AdminDeleteNotebook(ctx context.Context, req *pb.AdminDeleteNot
 	return &pb.DeleteNotebookResponse{}, nil
 }
 
+func (s *Server) AdminSetUserNotebooksPrivate(ctx context.Context, req *pb.AdminSetUserNotebooksPrivateRequest) (*pb.AdminSetUserNotebooksPrivateResponse, error) {
+	if err := s.notebookUC.SetAllPrivateByOwner(ctx, req.GetOwnerId()); err != nil {
+		return nil, grpcutil.DomainToGRPCError(err)
+	}
+	return &pb.AdminSetUserNotebooksPrivateResponse{}, nil
+}
+
+func (s *Server) AdminGetNotebookCount(ctx context.Context, _ *pb.AdminGetNotebookCountRequest) (*pb.AdminGetNotebookCountResponse, error) {
+	count, err := s.notebookUC.CountAll(ctx, "")
+	if err != nil {
+		return nil, grpcutil.DomainToGRPCError(err)
+	}
+	return &pb.AdminGetNotebookCountResponse{Total: int64(count)}, nil
+}
+
 func (s *Server) GrantPermission(ctx context.Context, req *pb.GrantPermissionRequest) (*pb.GrantPermissionResponse, error) {
 	err := s.notebookUC.GrantPermission(ctx, req.GetRequesterId(), req.GetNotebookId(), req.GetTargetUserId(), req.GetLevel())
 	if err != nil {

--- a/internal/notebook/repository/interfaces.go
+++ b/internal/notebook/repository/interfaces.go
@@ -18,6 +18,7 @@ type NotebookRepository interface {
 	CountAll(ctx context.Context, search string) (int, error)
 	GetSharedWithUser(ctx context.Context, userID int64, limit, offset int) ([]domain.Notebook, error)
 	CountSharedWithUser(ctx context.Context, userID int64) (int, error)
+	SetAllPrivateByOwner(ctx context.Context, ownerID int64) error
 }
 
 type BlockRepository interface {

--- a/internal/notebook/repository/postgres/notebook.go
+++ b/internal/notebook/repository/postgres/notebook.go
@@ -246,3 +246,17 @@ func (r *NotebookRepo) CountSharedWithUser(ctx context.Context, userID int64) (i
 	logger.Info(ctx, "repo.notebooks.CountSharedWithUser", "duration", time.Since(start), "user_id", userID, "count", count)
 	return count, nil
 }
+
+func (r *NotebookRepo) SetAllPrivateByOwner(ctx context.Context, ownerID int64) error {
+	start := time.Now()
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE notebooks SET is_public = false WHERE owner_id = $1 AND is_public = true`,
+		ownerID,
+	)
+	if err != nil {
+		logger.Error(ctx, "repo.notebooks.SetAllPrivateByOwner", "error", err, "duration", time.Since(start), "owner_id", ownerID)
+		return err
+	}
+	logger.Info(ctx, "repo.notebooks.SetAllPrivateByOwner", "duration", time.Since(start), "owner_id", ownerID)
+	return nil
+}

--- a/internal/notebook/usecase/notebook.go
+++ b/internal/notebook/usecase/notebook.go
@@ -28,6 +28,7 @@ type NotebookService interface {
 	RevokePermission(ctx context.Context, requesterID, notebookID, targetUserID int64) error
 	ListPermissions(ctx context.Context, requesterID, notebookID int64) ([]domain.FilePermission, error)
 	ListSharedWithUser(ctx context.Context, userID int64, limit, offset int) ([]domain.Notebook, int, error)
+	SetAllPrivateByOwner(ctx context.Context, ownerID int64) error
 }
 
 type notebookService struct {
@@ -373,4 +374,8 @@ func (s *notebookService) ListSharedWithUser(ctx context.Context, userID int64, 
 	}
 	logger.Info(ctx, "usecase.notebook.ListSharedWithUser", "total", total)
 	return notebooks, total, nil
+}
+
+func (s *notebookService) SetAllPrivateByOwner(ctx context.Context, ownerID int64) error {
+	return s.notebookRepo.SetAllPrivateByOwner(ctx, ownerID)
 }

--- a/internal/pkg/dto/user.go
+++ b/internal/pkg/dto/user.go
@@ -7,27 +7,33 @@ import (
 )
 
 type UserResponse struct {
-	ID          int64     `json:"id"`
-	Username    string    `json:"username"`
-	Email       string    `json:"email"`
-	AvatarURL   string    `json:"avatar_url"`
-	Status      string    `json:"status"`
-	Description string    `json:"description"`
-	IsAdmin     bool      `json:"is_admin"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID               int64      `json:"id"`
+	Username         string     `json:"username"`
+	Email            string     `json:"email"`
+	AvatarURL        string     `json:"avatar_url"`
+	Status           string     `json:"status"`
+	Description      string     `json:"description"`
+	IsAdmin          bool       `json:"is_admin"`
+	Plan             string     `json:"plan"`
+	LastActiveAt     *time.Time `json:"last_active_at,omitempty"`
+	TotalTimeSeconds int64      `json:"total_time_seconds"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
 }
 
 func NewUserResponse(u *domain.User) UserResponse {
 	return UserResponse{
-		ID:          u.ID,
-		Username:    u.Username,
-		Email:       u.Email,
-		AvatarURL:   u.AvatarURL,
-		Status:      u.Status,
-		Description: u.Description,
-		IsAdmin:     u.IsAdmin,
-		CreatedAt:   u.CreatedAt,
-		UpdatedAt:   u.UpdatedAt,
+		ID:               u.ID,
+		Username:         u.Username,
+		Email:            u.Email,
+		AvatarURL:        u.AvatarURL,
+		Status:           u.Status,
+		Description:      u.Description,
+		IsAdmin:          u.IsAdmin,
+		Plan:             u.Plan,
+		LastActiveAt:     u.LastActiveAt,
+		TotalTimeSeconds: u.TotalTimeSeconds,
+		CreatedAt:        u.CreatedAt,
+		UpdatedAt:        u.UpdatedAt,
 	}
 }

--- a/internal/runner/grpc/notebook_adapter.go
+++ b/internal/runner/grpc/notebook_adapter.go
@@ -75,6 +75,10 @@ func (a *NotebookAdapter) GetSharedWithUser(ctx context.Context, userID int64, l
 	return notebooks, nil
 }
 
+func (a *NotebookAdapter) SetAllPrivateByOwner(_ context.Context, _ int64) error {
+	return errNotSupported
+}
+
 func (a *NotebookAdapter) CountSharedWithUser(ctx context.Context, userID int64) (int, error) {
 	resp, err := a.client.ListSharedWithUser(ctx, &pb.ListSharedWithUserRequest{
 		UserId: userID,

--- a/migrations/013_add_plan_and_time_tracking.sql
+++ b/migrations/013_add_plan_and_time_tracking.sql
@@ -1,0 +1,8 @@
+ALTER TABLE users ADD COLUMN IF NOT EXISTS plan TEXT NOT NULL DEFAULT 'free';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_active_at TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS total_time_seconds BIGINT NOT NULL DEFAULT 0;
+
+UPDATE users SET plan = 'admin' WHERE is_admin = TRUE;
+UPDATE users SET last_active_at = updated_at WHERE last_active_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_users_plan ON users(plan);


### PR DESCRIPTION
См: https://github.com/frontend-park-mail-ru/2026_1_KISS/pull/76

По бекенду начал с подписками возмится:
  Тарифы (поле plan):                                                            
  - free - базовый, по умолчанию. Лимит 3 часа использования сайта              
  - freeze - автоматически ставится когда free-пользователь исчерпал 3 часа.    
  Аккаунт в read-only режиме                                                 
  - Pro - без ограничений на использование                                      
  - Max - без ограничений + будущие фишки 
  - admin - доступ к админ-панели                                               
                                                                                 
  Бан:                                                                           
  - Отдельный от тарифа механизм (поле status)                                   
  - Забанить можно только пользователя в состоянии freeze                        
  - При бане: не может войти в аккаунт, данные сохраняются, публичные ноутбуки   
  становятся приватными                                                          
  - Разбана пока нет                                                             
                                                                                 
  Колонки в таблице:                                                             
  - Старые STATUS + ROLE объединены в одну колонку ГРУППА
  - Добавлены: АКТИВНОСТЬ (последний визит) и ОБЩЕЕ ВРЕМЯ (суммарное время на    
  сайте)

Перевел запросы к админки через `api/v1/admin`

добавил БДшки для хранения различных метрик