### PR TITLE
feat: persist block outputs and fix reorder execution

### DIFF
--- a/api/proto/notebook/notebook.proto
+++ b/api/proto/notebook/notebook.proto
@@ -26,6 +26,9 @@ service NotebookService {
   rpc ListSharedWithUser(ListSharedWithUserRequest) returns (ListNotebooksResponse);
 
   rpc SubscribeNotebook(SubscribeNotebookRequest) returns (stream NotebookEvent);
+
+  rpc SaveBlockOutputs(SaveBlockOutputsRequest) returns (SaveBlockOutputsResponse);
+  rpc ReorderBlocks(ReorderBlocksRequest) returns (ReorderBlocksResponse);
 }
 
 message NotebookInfo {
@@ -49,6 +52,16 @@ message BlockInfo {
   int64 created_at = 7;
   int64 updated_at = 8;
   optional int32 execution_count = 9;
+  repeated BlockOutputInfo outputs = 10;
+}
+
+message BlockOutputInfo {
+  int64  id          = 1;
+  int64  block_id    = 2;
+  int32  position    = 3;
+  string output_type = 4;
+  string content     = 5;
+  int64  created_at  = 6;
 }
 
 message CreateNotebookRequest {
@@ -217,3 +230,18 @@ message AdminGetNotebookCountRequest {}
 message AdminGetNotebookCountResponse {
   int64 total = 1;
 }
+
+message SaveBlockOutputsRequest {
+  int64 block_id = 1;
+  repeated BlockOutputInfo outputs = 2;
+}
+
+message SaveBlockOutputsResponse {}
+
+message ReorderBlocksRequest {
+  int64 user_id = 1;
+  int64 notebook_id = 2;
+  repeated int64 block_ids = 3;
+}
+
+message ReorderBlocksResponse {}

--- a/internal/gateway/handler/notebook_handler.go
+++ b/internal/gateway/handler/notebook_handler.go
@@ -32,6 +32,7 @@ func (h *NotebookHandler) RegisterRoutes(mux *http.ServeMux, authMw middleware.M
 	mux.Handle("POST /api/v1/notebooks/{id}/blocks", authMw(http.HandlerFunc(h.AddBlock)))
 	mux.Handle("PUT /api/v1/notebooks/{id}/blocks/{blockID}", authMw(http.HandlerFunc(h.UpdateBlock)))
 	mux.Handle("DELETE /api/v1/notebooks/{id}/blocks/{blockID}", authMw(http.HandlerFunc(h.DeleteBlock)))
+	mux.Handle("PUT /api/v1/notebooks/{id}/reorder", authMw(http.HandlerFunc(h.ReorderBlocks)))
 	mux.Handle("GET /api/v1/notebooks/{id}/permissions", authMw(http.HandlerFunc(h.ListPermissions)))
 	mux.Handle("POST /api/v1/notebooks/{id}/permissions/invite", authMw(http.HandlerFunc(h.GrantPermissionByIdentifier)))
 	mux.Handle("PUT /api/v1/notebooks/{id}/permissions/{userID}", authMw(http.HandlerFunc(h.GrantPermission)))
@@ -70,13 +71,20 @@ type notebookResponse struct {
 	UpdatedAt     time.Time       `json:"updated_at"`
 }
 
+type blockOutputResponse struct {
+	OutputType string `json:"output_type"`
+	Content    string `json:"content"`
+	Position   int    `json:"position"`
+}
+
 type blockResponse struct {
-	ID        int64     `json:"id"`
-	Type      string    `json:"type"`
-	Language  string    `json:"language"`
-	Content   string    `json:"content"`
-	Position  int       `json:"position"`
-	CreatedAt time.Time `json:"created_at"`
+	ID        int64                 `json:"id"`
+	Type      string                `json:"type"`
+	Language  string                `json:"language"`
+	Content   string                `json:"content"`
+	Position  int                   `json:"position"`
+	Outputs   []blockOutputResponse `json:"outputs,omitempty"`
+	CreatedAt time.Time             `json:"created_at"`
 }
 
 type notebookListResponse struct {
@@ -336,6 +344,42 @@ func (h *NotebookHandler) DeleteBlock(w http.ResponseWriter, r *http.Request) {
 	httputil.JSON(w, http.StatusOK, nil)
 }
 
+type reorderBlocksRequest struct {
+	BlockIDs []int64 `json:"block_ids"`
+}
+
+func (h *NotebookHandler) ReorderBlocks(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		httputil.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		httputil.Error(w, http.StatusBadRequest, "invalid notebook id")
+		return
+	}
+
+	var req reorderBlocksRequest
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	_, err = h.client.ReorderBlocks(r.Context(), &pb.ReorderBlocksRequest{
+		UserId:     user.ID,
+		NotebookId: id,
+		BlockIds:   req.BlockIDs,
+	})
+	if err != nil {
+		httputil.MapDomainError(w, grpcutil.GRPCToDomainError(err))
+		return
+	}
+
+	httputil.JSON(w, http.StatusOK, nil)
+}
+
 type grantPermissionRequest struct {
 	Level string `json:"level"`
 }
@@ -579,7 +623,7 @@ func protoNotebookToResponse(nb *pb.NotebookInfo) notebookResponse {
 }
 
 func protoBlockToResponse(b *pb.BlockInfo) blockResponse {
-	return blockResponse{
+	resp := blockResponse{
 		ID:        b.GetId(),
 		Type:      b.GetType(),
 		Language:  b.GetLanguage(),
@@ -587,4 +631,15 @@ func protoBlockToResponse(b *pb.BlockInfo) blockResponse {
 		Position:  int(b.GetPosition()),
 		CreatedAt: time.Unix(b.GetCreatedAt(), 0),
 	}
+	if len(b.GetOutputs()) > 0 {
+		resp.Outputs = make([]blockOutputResponse, len(b.GetOutputs()))
+		for i, o := range b.GetOutputs() {
+			resp.Outputs[i] = blockOutputResponse{
+				OutputType: o.GetOutputType(),
+				Content:    o.GetContent(),
+				Position:   int(o.GetPosition()),
+			}
+		}
+	}
+	return resp
 }

--- a/internal/gateway/handler/notebook_handler_test.go
+++ b/internal/gateway/handler/notebook_handler_test.go
@@ -545,6 +545,56 @@ func TestNotebookHandler_RevokePermission_InvalidUserID(t *testing.T) {
 	}
 }
 
+func TestNotebookHandler_ReorderBlocks_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockNotebookServiceClient(ctrl)
+
+	client.EXPECT().ReorderBlocks(gomock.Any(), gomock.Any()).
+		Return(&pb.ReorderBlocksResponse{}, nil)
+
+	h := NewNotebookHandler(client, nil)
+	body, _ := json.Marshal(reorderBlocksRequest{BlockIDs: []int64{3, 1, 2}})
+	req := httptest.NewRequest("PUT", "/api/v1/notebooks/1/reorder", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", "1")
+	req = withUser(req, 1)
+	rec := httptest.NewRecorder()
+
+	h.ReorderBlocks(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("want 200, got %d", rec.Code)
+	}
+}
+
+func TestNotebookHandler_ReorderBlocks_Unauthorized(t *testing.T) {
+	h := NewNotebookHandler(nil, nil)
+	req := httptest.NewRequest("PUT", "/api/v1/notebooks/1/reorder", nil)
+	req.SetPathValue("id", "1")
+	req = req.WithContext(context.Background())
+	rec := httptest.NewRecorder()
+
+	h.ReorderBlocks(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d", rec.Code)
+	}
+}
+
+func TestNotebookHandler_ReorderBlocks_InvalidID(t *testing.T) {
+	h := NewNotebookHandler(nil, nil)
+	req := httptest.NewRequest("PUT", "/api/v1/notebooks/abc/reorder", nil)
+	req.SetPathValue("id", "abc")
+	req = withUser(req, 1)
+	rec := httptest.NewRecorder()
+
+	h.ReorderBlocks(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", rec.Code)
+	}
+}
+
 func TestNotebookHandler_RevokePermission_GRPCError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	client := mocks.NewMockNotebookServiceClient(ctrl)

--- a/internal/mocks/notebook_grpc_client_mock.go
+++ b/internal/mocks/notebook_grpc_client_mock.go
@@ -322,6 +322,26 @@ func (mr *MockNotebookServiceClientMockRecorder) ListSharedWithUser(ctx, in any,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSharedWithUser", reflect.TypeOf((*MockNotebookServiceClient)(nil).ListSharedWithUser), varargs...)
 }
 
+// ReorderBlocks mocks base method.
+func (m *MockNotebookServiceClient) ReorderBlocks(ctx context.Context, in *notebook.ReorderBlocksRequest, opts ...grpc.CallOption) (*notebook.ReorderBlocksResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReorderBlocks", varargs...)
+	ret0, _ := ret[0].(*notebook.ReorderBlocksResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReorderBlocks indicates an expected call of ReorderBlocks.
+func (mr *MockNotebookServiceClientMockRecorder) ReorderBlocks(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReorderBlocks", reflect.TypeOf((*MockNotebookServiceClient)(nil).ReorderBlocks), varargs...)
+}
+
 // RevokePermission mocks base method.
 func (m *MockNotebookServiceClient) RevokePermission(ctx context.Context, in *notebook.RevokePermissionRequest, opts ...grpc.CallOption) (*notebook.RevokePermissionResponse, error) {
 	m.ctrl.T.Helper()
@@ -340,6 +360,26 @@ func (mr *MockNotebookServiceClientMockRecorder) RevokePermission(ctx, in any, o
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokePermission", reflect.TypeOf((*MockNotebookServiceClient)(nil).RevokePermission), varargs...)
+}
+
+// SaveBlockOutputs mocks base method.
+func (m *MockNotebookServiceClient) SaveBlockOutputs(ctx context.Context, in *notebook.SaveBlockOutputsRequest, opts ...grpc.CallOption) (*notebook.SaveBlockOutputsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SaveBlockOutputs", varargs...)
+	ret0, _ := ret[0].(*notebook.SaveBlockOutputsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SaveBlockOutputs indicates an expected call of SaveBlockOutputs.
+func (mr *MockNotebookServiceClientMockRecorder) SaveBlockOutputs(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveBlockOutputs", reflect.TypeOf((*MockNotebookServiceClient)(nil).SaveBlockOutputs), varargs...)
 }
 
 // SubscribeNotebook mocks base method.

--- a/internal/mocks/notebook_repo_mock.go
+++ b/internal/mocks/notebook_repo_mock.go
@@ -286,6 +286,49 @@ func (mr *MockBlockRepositoryMockRecorder) GetByNotebookID(ctx, notebookID any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByNotebookID", reflect.TypeOf((*MockBlockRepository)(nil).GetByNotebookID), ctx, notebookID)
 }
 
+// GetOutputsByBlockIDs mocks base method.
+func (m *MockBlockRepository) GetOutputsByBlockIDs(ctx context.Context, blockIDs []int64) (map[int64][]domain.BlockOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOutputsByBlockIDs", ctx, blockIDs)
+	ret0, _ := ret[0].(map[int64][]domain.BlockOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOutputsByBlockIDs indicates an expected call of GetOutputsByBlockIDs.
+func (mr *MockBlockRepositoryMockRecorder) GetOutputsByBlockIDs(ctx, blockIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOutputsByBlockIDs", reflect.TypeOf((*MockBlockRepository)(nil).GetOutputsByBlockIDs), ctx, blockIDs)
+}
+
+// ReorderBlocks mocks base method.
+func (m *MockBlockRepository) ReorderBlocks(ctx context.Context, notebookID int64, blockIDs []int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReorderBlocks", ctx, notebookID, blockIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReorderBlocks indicates an expected call of ReorderBlocks.
+func (mr *MockBlockRepositoryMockRecorder) ReorderBlocks(ctx, notebookID, blockIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReorderBlocks", reflect.TypeOf((*MockBlockRepository)(nil).ReorderBlocks), ctx, notebookID, blockIDs)
+}
+
+// SaveOutputs mocks base method.
+func (m *MockBlockRepository) SaveOutputs(ctx context.Context, blockID int64, outputs []domain.BlockOutput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveOutputs", ctx, blockID, outputs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveOutputs indicates an expected call of SaveOutputs.
+func (mr *MockBlockRepositoryMockRecorder) SaveOutputs(ctx, blockID, outputs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveOutputs", reflect.TypeOf((*MockBlockRepository)(nil).SaveOutputs), ctx, blockID, outputs)
+}
+
 // Update mocks base method.
 func (m *MockBlockRepository) Update(ctx context.Context, block *domain.Block) error {
 	m.ctrl.T.Helper()

--- a/internal/notebook/grpc/server.go
+++ b/internal/notebook/grpc/server.go
@@ -306,6 +306,29 @@ func notebookToProto(nb *domain.Notebook) *pb.NotebookInfo {
 	return info
 }
 
+func (s *Server) SaveBlockOutputs(ctx context.Context, req *pb.SaveBlockOutputsRequest) (*pb.SaveBlockOutputsResponse, error) {
+	outputs := make([]domain.BlockOutput, len(req.GetOutputs()))
+	for i, o := range req.GetOutputs() {
+		outputs[i] = domain.BlockOutput{
+			BlockID:    req.GetBlockId(),
+			Position:   int(o.GetPosition()),
+			OutputType: o.GetOutputType(),
+			Content:    o.GetContent(),
+		}
+	}
+	if err := s.notebookUC.SaveBlockOutputs(ctx, req.GetBlockId(), outputs); err != nil {
+		return nil, grpcutil.DomainToGRPCError(err)
+	}
+	return &pb.SaveBlockOutputsResponse{}, nil
+}
+
+func (s *Server) ReorderBlocks(ctx context.Context, req *pb.ReorderBlocksRequest) (*pb.ReorderBlocksResponse, error) {
+	if err := s.notebookUC.ReorderBlocks(ctx, req.GetUserId(), req.GetNotebookId(), req.GetBlockIds()); err != nil {
+		return nil, grpcutil.DomainToGRPCError(err)
+	}
+	return &pb.ReorderBlocksResponse{}, nil
+}
+
 func blockToProto(b *domain.Block) *pb.BlockInfo {
 	if b == nil {
 		return nil
@@ -323,6 +346,19 @@ func blockToProto(b *domain.Block) *pb.BlockInfo {
 	if b.ExecutionCount != nil {
 		v := int32(*b.ExecutionCount) //nolint:gosec // execution count fits int32
 		info.ExecutionCount = &v
+	}
+	if len(b.Outputs) > 0 {
+		info.Outputs = make([]*pb.BlockOutputInfo, len(b.Outputs))
+		for i, o := range b.Outputs {
+			info.Outputs[i] = &pb.BlockOutputInfo{
+				Id:         o.ID,
+				BlockId:    o.BlockID,
+				Position:   int32(o.Position), //nolint:gosec // output position fits int32
+				OutputType: o.OutputType,
+				Content:    o.Content,
+				CreatedAt:  o.CreatedAt.Unix(),
+			}
+		}
 	}
 	return info
 }

--- a/internal/notebook/repository/interfaces.go
+++ b/internal/notebook/repository/interfaces.go
@@ -27,6 +27,9 @@ type BlockRepository interface {
 	GetByNotebookID(ctx context.Context, notebookID int64) ([]domain.Block, error)
 	Update(ctx context.Context, block *domain.Block) error
 	Delete(ctx context.Context, blockID int64) error
+	SaveOutputs(ctx context.Context, blockID int64, outputs []domain.BlockOutput) error
+	GetOutputsByBlockIDs(ctx context.Context, blockIDs []int64) (map[int64][]domain.BlockOutput, error)
+	ReorderBlocks(ctx context.Context, notebookID int64, blockIDs []int64) error
 }
 
 type PermissionRepository interface {

--- a/internal/notebook/repository/postgres/block.go
+++ b/internal/notebook/repository/postgres/block.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/pkg/logger"
+	"github.com/lib/pq"
 )
 
 type BlockRepo struct {
@@ -48,7 +51,15 @@ func (r *BlockRepo) GetByID(ctx context.Context, blockID int64) (*domain.Block, 
 		logger.Error(ctx, "repo.blocks.GetByID", "error", err, "duration", time.Since(start), "block_id", blockID)
 		return nil, err
 	}
-	b.Outputs = []domain.BlockOutput{}
+	outputsMap, err := r.GetOutputsByBlockIDs(ctx, []int64{blockID})
+	if err != nil {
+		logger.Error(ctx, "repo.blocks.GetByID", "error", err, "duration", time.Since(start), "block_id", blockID)
+		return nil, err
+	}
+	b.Outputs = outputsMap[blockID]
+	if b.Outputs == nil {
+		b.Outputs = []domain.BlockOutput{}
+	}
 	logger.Info(ctx, "repo.blocks.GetByID", "duration", time.Since(start), "block_id", blockID)
 	return b, nil
 }
@@ -72,12 +83,28 @@ func (r *BlockRepo) GetByNotebookID(ctx context.Context, notebookID int64) ([]do
 			logger.Error(ctx, "repo.blocks.GetByNotebookID", "error", err, "duration", time.Since(start), "notebook_id", notebookID)
 			return nil, err
 		}
-		b.Outputs = []domain.BlockOutput{}
 		blocks = append(blocks, b)
 	}
 	if err := rows.Err(); err != nil {
 		logger.Error(ctx, "repo.blocks.GetByNotebookID", "error", err, "duration", time.Since(start), "notebook_id", notebookID)
 		return nil, err
+	}
+	if len(blocks) > 0 {
+		blockIDs := make([]int64, len(blocks))
+		for i := range blocks {
+			blockIDs[i] = blocks[i].ID
+		}
+		outputsMap, err := r.GetOutputsByBlockIDs(ctx, blockIDs)
+		if err != nil {
+			logger.Error(ctx, "repo.blocks.GetByNotebookID", "error", err, "duration", time.Since(start), "notebook_id", notebookID)
+			return nil, err
+		}
+		for i := range blocks {
+			blocks[i].Outputs = outputsMap[blocks[i].ID]
+			if blocks[i].Outputs == nil {
+				blocks[i].Outputs = []domain.BlockOutput{}
+			}
+		}
 	}
 	logger.Info(ctx, "repo.blocks.GetByNotebookID", "duration", time.Since(start), "notebook_id", notebookID, "count", len(blocks))
 	return blocks, nil
@@ -145,5 +172,114 @@ func (r *BlockRepo) Delete(ctx context.Context, blockID int64) error {
 		return err
 	}
 	logger.Info(ctx, "repo.blocks.Delete", "duration", time.Since(start), "block_id", blockID)
+	return nil
+}
+
+func (r *BlockRepo) SaveOutputs(ctx context.Context, blockID int64, outputs []domain.BlockOutput) error {
+	start := time.Now()
+	tx, err := r.db.Begin()
+	if err != nil {
+		logger.Error(ctx, "repo.blocks.SaveOutputs", "error", err, "duration", time.Since(start), "block_id", blockID)
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `DELETE FROM block_outputs WHERE block_id = $1`, blockID)
+	if err != nil {
+		logger.Error(ctx, "repo.blocks.SaveOutputs", "error", err, "duration", time.Since(start), "block_id", blockID)
+		return err
+	}
+
+	if len(outputs) > 0 {
+		valueStrings := make([]string, 0, len(outputs))
+		valueArgs := make([]interface{}, 0, len(outputs)*4)
+		for i, o := range outputs {
+			base := i * 4
+			valueStrings = append(valueStrings, fmt.Sprintf("($%d, $%d, $%d, $%d)", base+1, base+2, base+3, base+4))
+			valueArgs = append(valueArgs, blockID, o.Position, o.OutputType, o.Content)
+		}
+		query := "INSERT INTO block_outputs (block_id, position, output_type, content) VALUES " + strings.Join(valueStrings, ", ")
+		_, err = tx.ExecContext(ctx, query, valueArgs...)
+		if err != nil {
+			logger.Error(ctx, "repo.blocks.SaveOutputs", "error", err, "duration", time.Since(start), "block_id", blockID)
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		logger.Error(ctx, "repo.blocks.SaveOutputs", "error", err, "duration", time.Since(start), "block_id", blockID)
+		return err
+	}
+	logger.Info(ctx, "repo.blocks.SaveOutputs", "duration", time.Since(start), "block_id", blockID, "count", len(outputs))
+	return nil
+}
+
+func (r *BlockRepo) GetOutputsByBlockIDs(ctx context.Context, blockIDs []int64) (map[int64][]domain.BlockOutput, error) {
+	start := time.Now()
+	result := make(map[int64][]domain.BlockOutput)
+	if len(blockIDs) == 0 {
+		return result, nil
+	}
+
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, block_id, position, output_type, content, created_at FROM block_outputs WHERE block_id = ANY($1) ORDER BY block_id, position ASC`,
+		pq.Array(blockIDs),
+	)
+	if err != nil {
+		logger.Error(ctx, "repo.blocks.GetOutputsByBlockIDs", "error", err, "duration", time.Since(start))
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var o domain.BlockOutput
+		if err := rows.Scan(&o.ID, &o.BlockID, &o.Position, &o.OutputType, &o.Content, &o.CreatedAt); err != nil {
+			logger.Error(ctx, "repo.blocks.GetOutputsByBlockIDs", "error", err, "duration", time.Since(start))
+			return nil, err
+		}
+		result[o.BlockID] = append(result[o.BlockID], o)
+	}
+	if err := rows.Err(); err != nil {
+		logger.Error(ctx, "repo.blocks.GetOutputsByBlockIDs", "error", err, "duration", time.Since(start))
+		return nil, err
+	}
+	logger.Info(ctx, "repo.blocks.GetOutputsByBlockIDs", "duration", time.Since(start), "block_count", len(blockIDs))
+	return result, nil
+}
+
+func (r *BlockRepo) ReorderBlocks(ctx context.Context, notebookID int64, blockIDs []int64) error {
+	start := time.Now()
+	tx, err := r.db.Begin()
+	if err != nil {
+		logger.Error(ctx, "repo.blocks.ReorderBlocks", "error", err, "duration", time.Since(start), "notebook_id", notebookID)
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx,
+		`UPDATE blocks SET position = -(position + 1) WHERE notebook_id = $1`,
+		notebookID,
+	)
+	if err != nil {
+		logger.Error(ctx, "repo.blocks.ReorderBlocks", "error", err, "duration", time.Since(start), "notebook_id", notebookID)
+		return err
+	}
+
+	for i, blockID := range blockIDs {
+		_, err = tx.ExecContext(ctx,
+			`UPDATE blocks SET position = $1, updated_at = NOW() WHERE id = $2 AND notebook_id = $3`,
+			i, blockID, notebookID,
+		)
+		if err != nil {
+			logger.Error(ctx, "repo.blocks.ReorderBlocks", "error", err, "duration", time.Since(start), "notebook_id", notebookID, "block_id", blockID)
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		logger.Error(ctx, "repo.blocks.ReorderBlocks", "error", err, "duration", time.Since(start), "notebook_id", notebookID)
+		return err
+	}
+	logger.Info(ctx, "repo.blocks.ReorderBlocks", "duration", time.Since(start), "notebook_id", notebookID, "count", len(blockIDs))
 	return nil
 }

--- a/internal/notebook/repository/postgres/block.go
+++ b/internal/notebook/repository/postgres/block.go
@@ -198,7 +198,7 @@ func (r *BlockRepo) SaveOutputs(ctx context.Context, blockID int64, outputs []do
 			valueStrings = append(valueStrings, fmt.Sprintf("($%d, $%d, $%d, $%d)", base+1, base+2, base+3, base+4))
 			valueArgs = append(valueArgs, blockID, o.Position, o.OutputType, o.Content)
 		}
-		query := "INSERT INTO block_outputs (block_id, position, output_type, content) VALUES " + strings.Join(valueStrings, ", ")
+		query := "INSERT INTO block_outputs (block_id, position, output_type, content) VALUES " + strings.Join(valueStrings, ", ") //nolint:gosec // query is built from parameterized placeholders only
 		_, err = tx.ExecContext(ctx, query, valueArgs...)
 		if err != nil {
 			logger.Error(ctx, "repo.blocks.SaveOutputs", "error", err, "duration", time.Since(start), "block_id", blockID)

--- a/internal/notebook/repository/postgres/block_test.go
+++ b/internal/notebook/repository/postgres/block_test.go
@@ -97,6 +97,10 @@ func TestBlockRepo_GetByID(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"id", "notebook_id", "type", "language", "content", "position", "execution_count", "created_at", "updated_at"}).
 				AddRow(int64(7), int64(1), "code", "python", "x=1", 0, execCount, now, now))
 
+		mock.ExpectQuery(`SELECT id, block_id, position, output_type, content, created_at FROM block_outputs`).
+			WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "block_id", "position", "output_type", "content", "created_at"}))
+
 		b, err := repo.GetByID(context.Background(), 7)
 		if err != nil {
 			t.Fatalf("GetByID() error = %v", err)
@@ -136,6 +140,31 @@ func TestBlockRepo_GetByID(t *testing.T) {
 			t.Fatalf("unmet expectations: %v", err)
 		}
 	})
+
+	t.Run("output_load_error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+		now := time.Now()
+
+		mock.ExpectQuery(`SELECT id, notebook_id, type, language, content, position, execution_count, created_at, updated_at FROM blocks WHERE id`).
+			WithArgs(int64(7)).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "notebook_id", "type", "language", "content", "position", "execution_count", "created_at", "updated_at"}).
+				AddRow(int64(7), int64(1), "code", "python", "x=1", 0, nil, now, now))
+
+		mock.ExpectQuery(`SELECT id, block_id, position, output_type, content, created_at FROM block_outputs`).
+			WithArgs(sqlmock.AnyArg()).
+			WillReturnError(fmt.Errorf("output query error"))
+
+		_, err = repo.GetByID(context.Background(), 7)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
 }
 
 func TestBlockRepo_GetByNotebookID(t *testing.T) {
@@ -155,6 +184,10 @@ func TestBlockRepo_GetByNotebookID(t *testing.T) {
 				AddRow(int64(1), int64(1), "code", "python", "a=1", 0, nil, now, now).
 				AddRow(int64(2), int64(1), "markdown", "", "# Title", 1, nil, now, now))
 
+		mock.ExpectQuery(`SELECT id, block_id, position, output_type, content, created_at FROM block_outputs`).
+			WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "block_id", "position", "output_type", "content", "created_at"}))
+
 		blocks, err := repo.GetByNotebookID(context.Background(), 1)
 		if err != nil {
 			t.Fatalf("GetByNotebookID() error = %v", err)
@@ -170,6 +203,66 @@ func TestBlockRepo_GetByNotebookID(t *testing.T) {
 		}
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("with_outputs", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+		now := time.Now()
+
+		mock.ExpectQuery(`SELECT id, notebook_id, type, language, content, position, execution_count, created_at, updated_at FROM blocks WHERE notebook_id`).
+			WithArgs(int64(1)).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "notebook_id", "type", "language", "content", "position", "execution_count", "created_at", "updated_at"}).
+				AddRow(int64(1), int64(1), "code", "python", "print(42)", 0, nil, now, now))
+
+		mock.ExpectQuery(`SELECT id, block_id, position, output_type, content, created_at FROM block_outputs`).
+			WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "block_id", "position", "output_type", "content", "created_at"}).
+				AddRow(int64(10), int64(1), 0, "stdout", "42", now))
+
+		blocks, err := repo.GetByNotebookID(context.Background(), 1)
+		if err != nil {
+			t.Fatalf("GetByNotebookID() error = %v", err)
+		}
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		if len(blocks[0].Outputs) != 1 {
+			t.Fatalf("expected 1 output, got %d", len(blocks[0].Outputs))
+		}
+		if blocks[0].Outputs[0].Content != "42" {
+			t.Fatalf("expected output '42', got %q", blocks[0].Outputs[0].Content)
+		}
+	})
+
+	t.Run("output_load_error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+		now := time.Now()
+
+		mock.ExpectQuery(`SELECT id, notebook_id, type, language, content, position, execution_count, created_at, updated_at FROM blocks WHERE notebook_id`).
+			WithArgs(int64(1)).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "notebook_id", "type", "language", "content", "position", "execution_count", "created_at", "updated_at"}).
+				AddRow(int64(1), int64(1), "code", "python", "a=1", 0, nil, now, now))
+
+		mock.ExpectQuery(`SELECT id, block_id, position, output_type, content, created_at FROM block_outputs`).
+			WithArgs(sqlmock.AnyArg()).
+			WillReturnError(fmt.Errorf("output query error"))
+
+		_, err = repo.GetByNotebookID(context.Background(), 1)
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
 	})
 
@@ -304,6 +397,339 @@ func TestBlockRepo_Delete(t *testing.T) {
 		}
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+}
+
+func TestBlockRepo_SaveOutputs(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin()
+		mock.ExpectExec(`DELETE FROM block_outputs WHERE block_id`).
+			WithArgs(int64(7)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(`INSERT INTO block_outputs`).
+			WithArgs(int64(7), 0, "stdout", "hello", int64(7), 1, "stderr", "warn").
+			WillReturnResult(sqlmock.NewResult(0, 2))
+		mock.ExpectCommit()
+
+		outputs := []domain.BlockOutput{
+			{Position: 0, OutputType: "stdout", Content: "hello"},
+			{Position: 1, OutputType: "stderr", Content: "warn"},
+		}
+		err = repo.SaveOutputs(context.Background(), 7, outputs)
+		if err != nil {
+			t.Fatalf("SaveOutputs() error = %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("empty_outputs", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin()
+		mock.ExpectExec(`DELETE FROM block_outputs WHERE block_id`).
+			WithArgs(int64(7)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectCommit()
+
+		err = repo.SaveOutputs(context.Background(), 7, nil)
+		if err != nil {
+			t.Fatalf("SaveOutputs() error = %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("begin_error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin().WillReturnError(fmt.Errorf("begin error"))
+
+		err = repo.SaveOutputs(context.Background(), 7, nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("delete_error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin()
+		mock.ExpectExec(`DELETE FROM block_outputs WHERE block_id`).
+			WithArgs(int64(7)).
+			WillReturnError(fmt.Errorf("delete error"))
+		mock.ExpectRollback()
+
+		err = repo.SaveOutputs(context.Background(), 7, []domain.BlockOutput{{Position: 0, OutputType: "stdout", Content: "hi"}})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("commit_error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin()
+		mock.ExpectExec(`DELETE FROM block_outputs WHERE block_id`).
+			WithArgs(int64(7)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(`INSERT INTO block_outputs`).
+			WithArgs(int64(7), 0, "stdout", "hi").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit().WillReturnError(fmt.Errorf("commit error"))
+
+		err = repo.SaveOutputs(context.Background(), 7, []domain.BlockOutput{{Position: 0, OutputType: "stdout", Content: "hi"}})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("insert_error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin()
+		mock.ExpectExec(`DELETE FROM block_outputs WHERE block_id`).
+			WithArgs(int64(7)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(`INSERT INTO block_outputs`).
+			WithArgs(int64(7), 0, "stdout", "hi").
+			WillReturnError(fmt.Errorf("insert error"))
+		mock.ExpectRollback()
+
+		err = repo.SaveOutputs(context.Background(), 7, []domain.BlockOutput{{Position: 0, OutputType: "stdout", Content: "hi"}})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestBlockRepo_GetOutputsByBlockIDs(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+		now := time.Now()
+
+		mock.ExpectQuery(`SELECT id, block_id, position, output_type, content, created_at FROM block_outputs`).
+			WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "block_id", "position", "output_type", "content", "created_at"}).
+				AddRow(int64(1), int64(7), 0, "stdout", "hello", now).
+				AddRow(int64(2), int64(8), 0, "result", "42", now))
+
+		result, err := repo.GetOutputsByBlockIDs(context.Background(), []int64{7, 8})
+		if err != nil {
+			t.Fatalf("GetOutputsByBlockIDs() error = %v", err)
+		}
+		if len(result[7]) != 1 {
+			t.Fatalf("expected 1 output for block 7, got %d", len(result[7]))
+		}
+		if result[7][0].Content != "hello" {
+			t.Fatalf("expected content 'hello', got %q", result[7][0].Content)
+		}
+		if len(result[8]) != 1 {
+			t.Fatalf("expected 1 output for block 8, got %d", len(result[8]))
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("empty_ids", func(t *testing.T) {
+		db, _, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+		result, err := repo.GetOutputsByBlockIDs(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("GetOutputsByBlockIDs() error = %v", err)
+		}
+		if len(result) != 0 {
+			t.Fatalf("expected empty map, got %d entries", len(result))
+		}
+	})
+
+	t.Run("query_error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectQuery(`SELECT id, block_id, position, output_type, content, created_at FROM block_outputs`).
+			WithArgs(sqlmock.AnyArg()).
+			WillReturnError(fmt.Errorf("query error"))
+
+		_, err = repo.GetOutputsByBlockIDs(context.Background(), []int64{7})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestBlockRepo_ReorderBlocks(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin()
+		mock.ExpectExec(`UPDATE blocks SET position = -`).
+			WithArgs(int64(1)).
+			WillReturnResult(sqlmock.NewResult(0, 2))
+		mock.ExpectExec(`UPDATE blocks SET position`).
+			WithArgs(0, int64(3), int64(1)).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec(`UPDATE blocks SET position`).
+			WithArgs(1, int64(2), int64(1)).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit()
+
+		err = repo.ReorderBlocks(context.Background(), 1, []int64{3, 2})
+		if err != nil {
+			t.Fatalf("ReorderBlocks() error = %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("begin_error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin().WillReturnError(fmt.Errorf("begin error"))
+
+		err = repo.ReorderBlocks(context.Background(), 1, []int64{3, 2})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("negate_error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin()
+		mock.ExpectExec(`UPDATE blocks SET position = -`).
+			WithArgs(int64(1)).
+			WillReturnError(fmt.Errorf("negate error"))
+		mock.ExpectRollback()
+
+		err = repo.ReorderBlocks(context.Background(), 1, []int64{3, 2})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("commit_error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin()
+		mock.ExpectExec(`UPDATE blocks SET position = -`).
+			WithArgs(int64(1)).
+			WillReturnResult(sqlmock.NewResult(0, 2))
+		mock.ExpectExec(`UPDATE blocks SET position`).
+			WithArgs(0, int64(3), int64(1)).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit().WillReturnError(fmt.Errorf("commit error"))
+
+		err = repo.ReorderBlocks(context.Background(), 1, []int64{3})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("set_position_error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin()
+		mock.ExpectExec(`UPDATE blocks SET position = -`).
+			WithArgs(int64(1)).
+			WillReturnResult(sqlmock.NewResult(0, 2))
+		mock.ExpectExec(`UPDATE blocks SET position`).
+			WithArgs(0, int64(3), int64(1)).
+			WillReturnError(fmt.Errorf("set position error"))
+		mock.ExpectRollback()
+
+		err = repo.ReorderBlocks(context.Background(), 1, []int64{3, 2})
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
 	})
 }

--- a/internal/notebook/usecase/notebook.go
+++ b/internal/notebook/usecase/notebook.go
@@ -40,6 +40,8 @@ type NotebookService interface {
 	ListPermissions(ctx context.Context, requesterID, notebookID int64) ([]domain.FilePermission, error)
 	ListSharedWithUser(ctx context.Context, userID int64, limit, offset int) ([]domain.Notebook, int, error)
 	SetAllPrivateByOwner(ctx context.Context, ownerID int64) error
+	SaveBlockOutputs(ctx context.Context, blockID int64, outputs []domain.BlockOutput) error
+	ReorderBlocks(ctx context.Context, userID, notebookID int64, blockIDs []int64) error
 }
 
 type notebookService struct {
@@ -435,4 +437,58 @@ func blockToProto(b *domain.Block) *pb.BlockInfo {
 
 func (s *notebookService) SetAllPrivateByOwner(ctx context.Context, ownerID int64) error {
 	return s.notebookRepo.SetAllPrivateByOwner(ctx, ownerID)
+}
+
+func (s *notebookService) SaveBlockOutputs(ctx context.Context, blockID int64, outputs []domain.BlockOutput) error {
+	logger.Info(ctx, "usecase.notebook.SaveBlockOutputs", "block_id", blockID, "count", len(outputs))
+	if err := s.blockRepo.SaveOutputs(ctx, blockID, outputs); err != nil {
+		logger.Error(ctx, "usecase.notebook.SaveBlockOutputs", "error", err)
+		return err
+	}
+	return nil
+}
+
+func (s *notebookService) ReorderBlocks(ctx context.Context, userID, notebookID int64, blockIDs []int64) error {
+	logger.Info(ctx, "usecase.notebook.ReorderBlocks", "user_id", userID, "notebook_id", notebookID)
+
+	nb, err := s.notebookRepo.GetByID(ctx, notebookID)
+	if err != nil {
+		logger.Error(ctx, "usecase.notebook.ReorderBlocks", "error", err)
+		return err
+	}
+	if err := s.requireEditorAccess(ctx, nb, userID); err != nil {
+		logger.Error(ctx, "usecase.notebook.ReorderBlocks", "error", err)
+		return err
+	}
+	blocks, err := s.blockRepo.GetByNotebookID(ctx, notebookID)
+	if err != nil {
+		logger.Error(ctx, "usecase.notebook.ReorderBlocks", "error", err)
+		return err
+	}
+	if len(blockIDs) != len(blocks) {
+		logger.Error(ctx, "usecase.notebook.ReorderBlocks", "error", domain.ErrInvalidInput)
+		return domain.ErrInvalidInput
+	}
+	existingIDs := make(map[int64]bool, len(blocks))
+	for _, b := range blocks {
+		existingIDs[b.ID] = true
+	}
+	for _, id := range blockIDs {
+		if !existingIDs[id] {
+			logger.Error(ctx, "usecase.notebook.ReorderBlocks", "error", domain.ErrInvalidInput, "unknown_block_id", id)
+			return domain.ErrInvalidInput
+		}
+	}
+	if err := s.blockRepo.ReorderBlocks(ctx, notebookID, blockIDs); err != nil {
+		logger.Error(ctx, "usecase.notebook.ReorderBlocks", "error", err)
+		return err
+	}
+	logger.Info(ctx, "usecase.notebook.ReorderBlocks", "notebook_id", notebookID, "status", "ok")
+	s.publisher.Publish(notebookID, &pb.NotebookEvent{
+		Type:       pb.NotebookEvent_NOTEBOOK_UPDATED,
+		NotebookId: notebookID,
+		ActorId:    userID,
+		Timestamp:  time.Now().UnixMilli(),
+	})
+	return nil
 }

--- a/internal/runner/grpc/notebook_adapter.go
+++ b/internal/runner/grpc/notebook_adapter.go
@@ -141,6 +141,18 @@ func (a *BlockAdapter) Delete(_ context.Context, _ int64) error {
 	return errNotSupported
 }
 
+func (a *BlockAdapter) SaveOutputs(_ context.Context, _ int64, _ []domain.BlockOutput) error {
+	return errNotSupported
+}
+
+func (a *BlockAdapter) GetOutputsByBlockIDs(_ context.Context, _ []int64) (map[int64][]domain.BlockOutput, error) {
+	return nil, errNotSupported
+}
+
+func (a *BlockAdapter) ReorderBlocks(_ context.Context, _ int64, _ []int64) error {
+	return errNotSupported
+}
+
 func protoToNotebook(info *pb.NotebookInfo) *domain.Notebook {
 	if info == nil {
 		return nil

--- a/internal/runner/grpc/server.go
+++ b/internal/runner/grpc/server.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -9,6 +10,7 @@ import (
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/pkg/ctxutil"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/pkg/grpcutil"
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/pkg/logger"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/runner/runner_service"
 	pbnotebook "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/notebook"
 	pb "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/runner"
@@ -43,6 +45,9 @@ func (s *Server) ExecuteFromPosition(ctx context.Context, req *pb.ExecuteFromPos
 	for i, r := range results {
 		pbResults[i] = executionResultToProto(r)
 	}
+
+	s.saveBlockOutputs(ctx, results)
+
 	return &pb.ExecuteFromPositionResponse{Results: pbResults}, nil
 }
 
@@ -60,6 +65,9 @@ func (s *Server) ExecuteBlock(ctx context.Context, req *pb.ExecuteBlockRequest) 
 	if err != nil {
 		return nil, grpcutil.DomainToGRPCError(err)
 	}
+
+	s.saveBlockOutputs(ctx, []*domain.BlockExecutionResult{result})
+
 	return &pb.ExecuteBlockResponse{Result: executionResultToProto(result)}, nil
 }
 
@@ -84,6 +92,60 @@ func (s *Server) checkNotebookAccess(ctx context.Context, userID, notebookID int
 		NotebookId: notebookID,
 	})
 	return err
+}
+
+func (s *Server) saveBlockOutputs(ctx context.Context, results []*domain.BlockExecutionResult) {
+	for _, r := range results {
+		if r == nil || r.Error != nil {
+			continue
+		}
+		outputs := resultToOutputProtos(r)
+		if len(outputs) == 0 {
+			continue
+		}
+		_, err := s.nbClient.SaveBlockOutputs(ctx, &pbnotebook.SaveBlockOutputsRequest{
+			BlockId: r.BlockID,
+			Outputs: outputs,
+		})
+		if err != nil {
+			logger.Error(ctx, "runner.SaveBlockOutputs", "error", err, "block_id", r.BlockID)
+		}
+	}
+}
+
+func resultToOutputProtos(r *domain.BlockExecutionResult) []*pbnotebook.BlockOutputInfo {
+	var outputs []*pbnotebook.BlockOutputInfo
+	pos := int32(0)
+
+	if stdout := strings.Join(r.Stdout, "\n"); stdout != "" {
+		outputs = append(outputs, &pbnotebook.BlockOutputInfo{
+			Position: pos, OutputType: "stdout", Content: stdout,
+		})
+	}
+	pos++
+
+	if stderr := strings.Join(r.Stderr, "\n"); stderr != "" {
+		outputs = append(outputs, &pbnotebook.BlockOutputInfo{
+			Position: pos, OutputType: "stderr", Content: stderr,
+		})
+	}
+	pos++
+
+	if r.Result != "" {
+		outputs = append(outputs, &pbnotebook.BlockOutputInfo{
+			Position: pos, OutputType: "result", Content: r.Result,
+		})
+	}
+	pos++
+
+	for _, item := range r.Outputs {
+		outputs = append(outputs, &pbnotebook.BlockOutputInfo{
+			Position: pos, OutputType: item.MimeType, Content: item.Data,
+		})
+		pos++
+	}
+
+	return outputs
 }
 
 func executionResultToProto(r *domain.BlockExecutionResult) *pb.BlockExecutionResult {

--- a/internal/runner/notebook_session/notebook_session.go
+++ b/internal/runner/notebook_session/notebook_session.go
@@ -85,6 +85,20 @@ func (s *notebookSession) ExecuteFromPosition(
 	copy(blocks, notebook.Blocks)
 	sort.Slice(blocks, func(i, j int) bool { return blocks[i].Position < blocks[j].Position })
 
+	for _, block := range blocks {
+		if state, exists := s.BlockStates[block.ID]; exists {
+			if state.Position != block.Position {
+				for _, b := range blocks {
+					if st, ok := s.BlockStates[b.ID]; ok {
+						st.Position = b.Position
+						st.Executed = false
+					}
+				}
+				break
+			}
+		}
+	}
+
 	for i := startPosition; i < len(blocks); i++ {
 		block := blocks[i]
 		if block.Type != "code" {


### PR DESCRIPTION
Добавление вывода сохраненных блоков. Теперь вывод при выполнении блока не забываются, а сохраняется