### PR TITLE
feat: импорт ноутбука из .ipynb

### DIFF
--- a/api/proto/notebook/notebook.proto
+++ b/api/proto/notebook/notebook.proto
@@ -29,6 +29,7 @@ service NotebookService {
 
   rpc SaveBlockOutputs(SaveBlockOutputsRequest) returns (SaveBlockOutputsResponse);
   rpc ReorderBlocks(ReorderBlocksRequest) returns (ReorderBlocksResponse);
+  rpc ImportNotebook(ImportNotebookRequest) returns (NotebookResponse);
 }
 
 message NotebookInfo {
@@ -245,3 +246,17 @@ message ReorderBlocksRequest {
 }
 
 message ReorderBlocksResponse {}
+
+message ImportNotebookRequest {
+  int64 user_id = 1;
+  string title = 2;
+  repeated ImportBlockInfo blocks = 3;
+}
+
+message ImportBlockInfo {
+  string type = 1;
+  string language = 2;
+  string content = 3;
+  int32 position = 4;
+  repeated BlockOutputInfo outputs = 5;
+}

--- a/internal/gateway/handler/notebook_handler.go
+++ b/internal/gateway/handler/notebook_handler.go
@@ -33,6 +33,7 @@ func (h *NotebookHandler) RegisterRoutes(mux *http.ServeMux, authMw middleware.M
 	mux.Handle("PUT /api/v1/notebooks/{id}/blocks/{blockID}", authMw(http.HandlerFunc(h.UpdateBlock)))
 	mux.Handle("DELETE /api/v1/notebooks/{id}/blocks/{blockID}", authMw(http.HandlerFunc(h.DeleteBlock)))
 	mux.Handle("PUT /api/v1/notebooks/{id}/reorder", authMw(http.HandlerFunc(h.ReorderBlocks)))
+	mux.Handle("POST /api/v1/notebooks/import", authMw(http.HandlerFunc(h.ImportNotebook)))
 	mux.Handle("GET /api/v1/notebooks/{id}/permissions", authMw(http.HandlerFunc(h.ListPermissions)))
 	mux.Handle("POST /api/v1/notebooks/{id}/permissions/invite", authMw(http.HandlerFunc(h.GrantPermissionByIdentifier)))
 	mux.Handle("PUT /api/v1/notebooks/{id}/permissions/{userID}", authMw(http.HandlerFunc(h.GrantPermission)))
@@ -344,6 +345,25 @@ func (h *NotebookHandler) DeleteBlock(w http.ResponseWriter, r *http.Request) {
 	httputil.JSON(w, http.StatusOK, nil)
 }
 
+type importNotebookRequest struct {
+	Title  string               `json:"title"`
+	Blocks []importBlockRequest `json:"blocks"`
+}
+
+type importBlockRequest struct {
+	Type     string              `json:"type"`
+	Language string              `json:"language"`
+	Content  string              `json:"content"`
+	Position int                 `json:"position"`
+	Outputs  []importBlockOutput `json:"outputs,omitempty"`
+}
+
+type importBlockOutput struct {
+	OutputType string `json:"output_type"`
+	Content    string `json:"content"`
+	Position   int    `json:"position"`
+}
+
 type reorderBlocksRequest struct {
 	BlockIDs []int64 `json:"block_ids"`
 }
@@ -398,6 +418,51 @@ type permissionResponse struct {
 
 type permissionListResponse struct {
 	Permissions []permissionResponse `json:"permissions"`
+}
+
+func (h *NotebookHandler) ImportNotebook(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		httputil.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	var req importNotebookRequest
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	pbBlocks := make([]*pb.ImportBlockInfo, len(req.Blocks))
+	for i, b := range req.Blocks {
+		pbOutputs := make([]*pb.BlockOutputInfo, len(b.Outputs))
+		for j, o := range b.Outputs {
+			pbOutputs[j] = &pb.BlockOutputInfo{
+				Position:   int32(o.Position), //nolint:gosec // output position fits int32
+				OutputType: o.OutputType,
+				Content:    o.Content,
+			}
+		}
+		pbBlocks[i] = &pb.ImportBlockInfo{
+			Type:     b.Type,
+			Language: b.Language,
+			Content:  b.Content,
+			Position: int32(b.Position), //nolint:gosec // block position fits int32
+			Outputs:  pbOutputs,
+		}
+	}
+
+	resp, err := h.client.ImportNotebook(r.Context(), &pb.ImportNotebookRequest{
+		UserId: user.ID,
+		Title:  req.Title,
+		Blocks: pbBlocks,
+	})
+	if err != nil {
+		httputil.MapDomainError(w, grpcutil.GRPCToDomainError(err))
+		return
+	}
+
+	httputil.JSON(w, http.StatusCreated, protoNotebookToResponse(resp.GetNotebook()))
 }
 
 func (h *NotebookHandler) ListShared(w http.ResponseWriter, r *http.Request) {

--- a/internal/gateway/handler/notebook_handler_test.go
+++ b/internal/gateway/handler/notebook_handler_test.go
@@ -595,6 +595,54 @@ func TestNotebookHandler_ReorderBlocks_InvalidID(t *testing.T) {
 	}
 }
 
+func TestNotebookHandler_ImportNotebook_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockNotebookServiceClient(ctrl)
+
+	client.EXPECT().ImportNotebook(gomock.Any(), gomock.Any()).
+		Return(&pb.NotebookResponse{
+			Notebook: &pb.NotebookInfo{
+				Id: 1, OwnerId: 1, Title: "Imported",
+				Blocks: []*pb.BlockInfo{
+					{Id: 10, Type: "code", Language: "python", Content: "print('hi')", Position: 0},
+				},
+			},
+		}, nil)
+
+	h := NewNotebookHandler(client, nil)
+	body, _ := json.Marshal(importNotebookRequest{
+		Title: "Imported",
+		Blocks: []importBlockRequest{
+			{Type: "code", Language: "python", Content: "print('hi')", Position: 0},
+		},
+	})
+	req := httptest.NewRequest("POST", "/api/v1/notebooks/import", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, 1)
+	rec := httptest.NewRecorder()
+
+	h.ImportNotebook(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("want 201, got %d", rec.Code)
+	}
+}
+
+func TestNotebookHandler_ImportNotebook_Unauthorized(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockNotebookServiceClient(ctrl)
+
+	h := NewNotebookHandler(client, nil)
+	req := httptest.NewRequest("POST", "/api/v1/notebooks/import", nil)
+	rec := httptest.NewRecorder()
+
+	h.ImportNotebook(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d", rec.Code)
+	}
+}
+
 func TestNotebookHandler_RevokePermission_GRPCError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	client := mocks.NewMockNotebookServiceClient(ctrl)

--- a/internal/mocks/notebook_grpc_client_mock.go
+++ b/internal/mocks/notebook_grpc_client_mock.go
@@ -262,6 +262,26 @@ func (mr *MockNotebookServiceClientMockRecorder) GrantPermission(ctx, in any, op
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantPermission", reflect.TypeOf((*MockNotebookServiceClient)(nil).GrantPermission), varargs...)
 }
 
+// ImportNotebook mocks base method.
+func (m *MockNotebookServiceClient) ImportNotebook(ctx context.Context, in *notebook.ImportNotebookRequest, opts ...grpc.CallOption) (*notebook.NotebookResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ImportNotebook", varargs...)
+	ret0, _ := ret[0].(*notebook.NotebookResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImportNotebook indicates an expected call of ImportNotebook.
+func (mr *MockNotebookServiceClientMockRecorder) ImportNotebook(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportNotebook", reflect.TypeOf((*MockNotebookServiceClient)(nil).ImportNotebook), varargs...)
+}
+
 // ListByUser mocks base method.
 func (m *MockNotebookServiceClient) ListByUser(ctx context.Context, in *notebook.ListNotebooksRequest, opts ...grpc.CallOption) (*notebook.ListNotebooksResponse, error) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/notebook_repo_mock.go
+++ b/internal/mocks/notebook_repo_mock.go
@@ -242,6 +242,21 @@ func (mr *MockBlockRepositoryMockRecorder) Create(ctx, block any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockBlockRepository)(nil).Create), ctx, block)
 }
 
+// CreateBatch mocks base method.
+func (m *MockBlockRepository) CreateBatch(ctx context.Context, blocks []domain.Block) ([]int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateBatch", ctx, blocks)
+	ret0, _ := ret[0].([]int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateBatch indicates an expected call of CreateBatch.
+func (mr *MockBlockRepositoryMockRecorder) CreateBatch(ctx, blocks any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBatch", reflect.TypeOf((*MockBlockRepository)(nil).CreateBatch), ctx, blocks)
+}
+
 // Delete mocks base method.
 func (m *MockBlockRepository) Delete(ctx context.Context, blockID int64) error {
 	m.ctrl.T.Helper()

--- a/internal/notebook/grpc/server.go
+++ b/internal/notebook/grpc/server.go
@@ -322,6 +322,30 @@ func (s *Server) SaveBlockOutputs(ctx context.Context, req *pb.SaveBlockOutputsR
 	return &pb.SaveBlockOutputsResponse{}, nil
 }
 
+func (s *Server) ImportNotebook(ctx context.Context, req *pb.ImportNotebookRequest) (*pb.NotebookResponse, error) {
+	blocks := make([]domain.Block, len(req.GetBlocks()))
+	for i, b := range req.GetBlocks() {
+		blocks[i] = domain.Block{
+			Type:     b.GetType(),
+			Language: b.GetLanguage(),
+			Content:  b.GetContent(),
+			Position: int(b.GetPosition()),
+		}
+		for _, o := range b.GetOutputs() {
+			blocks[i].Outputs = append(blocks[i].Outputs, domain.BlockOutput{
+				Position:   int(o.GetPosition()),
+				OutputType: o.GetOutputType(),
+				Content:    o.GetContent(),
+			})
+		}
+	}
+	nb, err := s.notebookUC.ImportNotebook(ctx, req.GetUserId(), req.GetTitle(), blocks)
+	if err != nil {
+		return nil, grpcutil.DomainToGRPCError(err)
+	}
+	return &pb.NotebookResponse{Notebook: notebookToProto(nb)}, nil
+}
+
 func (s *Server) ReorderBlocks(ctx context.Context, req *pb.ReorderBlocksRequest) (*pb.ReorderBlocksResponse, error) {
 	if err := s.notebookUC.ReorderBlocks(ctx, req.GetUserId(), req.GetNotebookId(), req.GetBlockIds()); err != nil {
 		return nil, grpcutil.DomainToGRPCError(err)

--- a/internal/notebook/repository/interfaces.go
+++ b/internal/notebook/repository/interfaces.go
@@ -30,6 +30,7 @@ type BlockRepository interface {
 	SaveOutputs(ctx context.Context, blockID int64, outputs []domain.BlockOutput) error
 	GetOutputsByBlockIDs(ctx context.Context, blockIDs []int64) (map[int64][]domain.BlockOutput, error)
 	ReorderBlocks(ctx context.Context, notebookID int64, blockIDs []int64) error
+	CreateBatch(ctx context.Context, blocks []domain.Block) ([]int64, error)
 }
 
 type PermissionRepository interface {

--- a/internal/notebook/repository/postgres/block.go
+++ b/internal/notebook/repository/postgres/block.go
@@ -247,6 +247,39 @@ func (r *BlockRepo) GetOutputsByBlockIDs(ctx context.Context, blockIDs []int64) 
 	return result, nil
 }
 
+func (r *BlockRepo) CreateBatch(ctx context.Context, blocks []domain.Block) ([]int64, error) {
+	start := time.Now()
+	tx, err := r.db.Begin()
+	if err != nil {
+		logger.Error(ctx, "repo.blocks.CreateBatch", "error", err, "duration", time.Since(start))
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	ids := make([]int64, len(blocks))
+	for i := range blocks {
+		b := &blocks[i]
+		var id int64
+		err := tx.QueryRowContext(ctx,
+			`INSERT INTO blocks (notebook_id, type, language, content, position) VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+			b.NotebookID, b.Type, b.Language, b.Content, b.Position,
+		).Scan(&id)
+		if err != nil {
+			logger.Error(ctx, "repo.blocks.CreateBatch", "error", err, "duration", time.Since(start), "position", b.Position)
+			return nil, err
+		}
+		ids[i] = id
+		b.ID = id
+	}
+
+	if err := tx.Commit(); err != nil {
+		logger.Error(ctx, "repo.blocks.CreateBatch", "error", err, "duration", time.Since(start))
+		return nil, err
+	}
+	logger.Info(ctx, "repo.blocks.CreateBatch", "duration", time.Since(start), "count", len(blocks))
+	return ids, nil
+}
+
 func (r *BlockRepo) ReorderBlocks(ctx context.Context, notebookID int64, blockIDs []int64) error {
 	start := time.Now()
 	tx, err := r.db.Begin()

--- a/internal/notebook/repository/postgres/block_test.go
+++ b/internal/notebook/repository/postgres/block_test.go
@@ -733,3 +733,79 @@ func TestBlockRepo_ReorderBlocks(t *testing.T) {
 		}
 	})
 }
+
+func TestBlockRepo_CreateBatch(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin()
+		mock.ExpectQuery(`INSERT INTO blocks`).
+			WithArgs(int64(1), "code", "python", "print('hi')", 0).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(10)))
+		mock.ExpectQuery(`INSERT INTO blocks`).
+			WithArgs(int64(1), "text", "markdown", "# hello", 1).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(11)))
+		mock.ExpectCommit()
+
+		blocks := []domain.Block{
+			{NotebookID: 1, Type: "code", Language: "python", Content: "print('hi')", Position: 0},
+			{NotebookID: 1, Type: "text", Language: "markdown", Content: "# hello", Position: 1},
+		}
+
+		ids, err := repo.CreateBatch(context.Background(), blocks)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 2 || ids[0] != 10 || ids[1] != 11 {
+			t.Errorf("want ids [10 11], got %v", ids)
+		}
+	})
+
+	t.Run("insert_error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin()
+		mock.ExpectQuery(`INSERT INTO blocks`).
+			WithArgs(int64(1), "code", "python", "", 0).
+			WillReturnError(fmt.Errorf("insert error"))
+		mock.ExpectRollback()
+
+		blocks := []domain.Block{
+			{NotebookID: 1, Type: "code", Language: "python", Content: "", Position: 0},
+		}
+
+		_, err = repo.CreateBatch(context.Background(), blocks)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("begin_error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New() error = %v", err)
+		}
+		defer db.Close()
+
+		repo := NewBlockRepository(db)
+
+		mock.ExpectBegin().WillReturnError(fmt.Errorf("begin error"))
+
+		_, err = repo.CreateBatch(context.Background(), []domain.Block{{NotebookID: 1}})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}

--- a/internal/notebook/usecase/notebook.go
+++ b/internal/notebook/usecase/notebook.go
@@ -42,6 +42,7 @@ type NotebookService interface {
 	SetAllPrivateByOwner(ctx context.Context, ownerID int64) error
 	SaveBlockOutputs(ctx context.Context, blockID int64, outputs []domain.BlockOutput) error
 	ReorderBlocks(ctx context.Context, userID, notebookID int64, blockIDs []int64) error
+	ImportNotebook(ctx context.Context, userID int64, title string, blocks []domain.Block) (*domain.Notebook, error)
 }
 
 type notebookService struct {
@@ -433,6 +434,57 @@ func blockToProto(b *domain.Block) *pb.BlockInfo {
 		CreatedAt:  b.CreatedAt.Unix(),
 		UpdatedAt:  b.UpdatedAt.Unix(),
 	}
+}
+
+func (s *notebookService) ImportNotebook(ctx context.Context, userID int64, title string, blocks []domain.Block) (*domain.Notebook, error) {
+	logger.Info(ctx, "usecase.notebook.ImportNotebook", "user_id", userID, "title", title, "block_count", len(blocks))
+
+	title = sanitize.EscapeHTML(title)
+	if title == "" {
+		title = "Imported"
+	}
+	if utf8.RuneCountInString(title) > 255 {
+		title = string([]rune(title)[:255])
+	}
+
+	nb := &domain.Notebook{OwnerID: userID, Title: title}
+	id, err := s.notebookRepo.Create(ctx, nb)
+	if err != nil {
+		logger.Error(ctx, "usecase.notebook.ImportNotebook", "error", err)
+		return nil, err
+	}
+	nb.ID = id
+
+	for i := range blocks {
+		blocks[i].NotebookID = nb.ID
+		blocks[i].Position = i
+		if blocks[i].Type == "text" && blocks[i].Language == "" {
+			blocks[i].Language = "markdown"
+		}
+		if blocks[i].Type == "code" && blocks[i].Language == "" {
+			blocks[i].Language = "python"
+		}
+	}
+
+	if len(blocks) > 0 {
+		ids, err := s.blockRepo.CreateBatch(ctx, blocks)
+		if err != nil {
+			logger.Error(ctx, "usecase.notebook.ImportNotebook", "error", err)
+			return nil, err
+		}
+		for i, blockID := range ids {
+			blocks[i].ID = blockID
+			if len(blocks[i].Outputs) > 0 {
+				if err := s.blockRepo.SaveOutputs(ctx, blockID, blocks[i].Outputs); err != nil {
+					logger.Error(ctx, "usecase.notebook.ImportNotebook.SaveOutputs", "error", err, "block_id", blockID)
+				}
+			}
+		}
+	}
+
+	nb.Blocks = blocks
+	logger.Info(ctx, "usecase.notebook.ImportNotebook", "notebook_id", nb.ID, "block_count", len(blocks))
+	return nb, nil
 }
 
 func (s *notebookService) SetAllPrivateByOwner(ctx context.Context, ownerID int64) error {

--- a/internal/notebook/usecase/notebook_test.go
+++ b/internal/notebook/usecase/notebook_test.go
@@ -1112,6 +1112,79 @@ func TestRequireEditorAccess_ReadonlyPermission(t *testing.T) {
 	}
 }
 
+func TestImportNotebook_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	notebookRepo := mocks.NewMockNotebookRepository(ctrl)
+	blockRepo := mocks.NewMockBlockRepository(ctrl)
+
+	notebookRepo.EXPECT().Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, nb *domain.Notebook) (int64, error) {
+			nb.ID = 100
+			return 100, nil
+		})
+	blockRepo.EXPECT().CreateBatch(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, blocks []domain.Block) ([]int64, error) {
+			if len(blocks) != 2 {
+				t.Errorf("want 2 blocks, got %d", len(blocks))
+			}
+			if blocks[0].NotebookID != 100 || blocks[1].NotebookID != 100 {
+				t.Error("blocks should have notebook_id=100")
+			}
+			return []int64{1, 2}, nil
+		})
+	blockRepo.EXPECT().SaveOutputs(gomock.Any(), int64(1), gomock.Any()).Return(nil)
+
+	uc := usecase.New(notebookRepo, blockRepo, mocks.NewMockPermissionRepository(ctrl))
+	blocks := []domain.Block{
+		{Type: "code", Content: "print('hi')", Outputs: []domain.BlockOutput{{OutputType: "stdout", Content: "hi"}}},
+		{Type: "text", Content: "# hello"},
+	}
+	nb, err := uc.ImportNotebook(context.Background(), 1, "Test NB", blocks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if nb.ID != 100 {
+		t.Errorf("want notebook id 100, got %d", nb.ID)
+	}
+	if len(nb.Blocks) != 2 {
+		t.Errorf("want 2 blocks, got %d", len(nb.Blocks))
+	}
+}
+
+func TestImportNotebook_CreateError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	notebookRepo := mocks.NewMockNotebookRepository(ctrl)
+	blockRepo := mocks.NewMockBlockRepository(ctrl)
+
+	notebookRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(int64(0), errors.New("db error"))
+
+	uc := usecase.New(notebookRepo, blockRepo, mocks.NewMockPermissionRepository(ctrl))
+	_, err := uc.ImportNotebook(context.Background(), 1, "Test", []domain.Block{{Type: "code"}})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestImportNotebook_EmptyBlocks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	notebookRepo := mocks.NewMockNotebookRepository(ctrl)
+	blockRepo := mocks.NewMockBlockRepository(ctrl)
+
+	notebookRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(int64(1), nil)
+
+	uc := usecase.New(notebookRepo, blockRepo, mocks.NewMockPermissionRepository(ctrl))
+	nb, err := uc.ImportNotebook(context.Background(), 1, "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if nb.Title != "Imported" {
+		t.Errorf("want title 'Imported', got %q", nb.Title)
+	}
+}
+
 func TestRequireEditorAccess_RepoError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/internal/runner/grpc/notebook_adapter.go
+++ b/internal/runner/grpc/notebook_adapter.go
@@ -153,6 +153,10 @@ func (a *BlockAdapter) ReorderBlocks(_ context.Context, _ int64, _ []int64) erro
 	return errNotSupported
 }
 
+func (a *BlockAdapter) CreateBatch(_ context.Context, _ []domain.Block) ([]int64, error) {
+	return nil, errNotSupported
+}
+
 func protoToNotebook(info *pb.NotebookInfo) *domain.Notebook {
 	if info == nil {
 		return nil

--- a/internal/runner/grpc/server_test.go
+++ b/internal/runner/grpc/server_test.go
@@ -80,6 +80,7 @@ func TestExecuteBlock_Success(t *testing.T) {
 		ExecutedAt: time.Now(),
 		Duration:   100 * time.Millisecond,
 	}, nil)
+	nbClient.EXPECT().SaveBlockOutputs(gomock.Any(), gomock.Any()).Return(&pbnotebook.SaveBlockOutputsResponse{}, nil)
 
 	resp, err := client.ExecuteBlock(context.Background(), &pb.ExecuteBlockRequest{
 		NotebookId:    1,


### PR DESCRIPTION
Добавлен эндпоинт POST /notebooks/import для атомарного создания ноутбука с блоками и outputs из .ipynb файла.