### PR TITLE
fix(runner): восстановление runner app после PR #27

### DIFF
--- a/internal/runner/app/app.go
+++ b/internal/runner/app/app.go
@@ -2,44 +2,62 @@ package app
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
-	nbgrpc "github.com/go-park-mail-ru/2026_1_KISS/internal/notebook/grpc"
-	nbpg "github.com/go-park-mail-ru/2026_1_KISS/internal/notebook/repository/postgres"
-	nbusecase "github.com/go-park-mail-ru/2026_1_KISS/internal/notebook/usecase"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/pkg/config"
-	"github.com/go-park-mail-ru/2026_1_KISS/internal/pkg/database"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/pkg/grpcutil"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/pkg/metrics"
-	pb "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/notebook"
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/runner/container"
+	runnergrpc "github.com/go-park-mail-ru/2026_1_KISS/internal/runner/grpc"
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/runner/runner_service"
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/runner/session_repository"
+	pbnotebook "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/notebook"
+	pbrunner "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/runner"
 )
 
 type App struct {
-	grpcServer *grpc.Server
-	listener   net.Listener
-	db         *sql.DB
-	metricsSrv *http.Server
+	grpcServer    *grpc.Server
+	listener      net.Listener
+	runnerManager container.Manager
+	cancelReaper  context.CancelFunc
+	nbConn        *grpc.ClientConn
+	metricsSrv    *http.Server
 }
 
 func New(cfg *config.Config, grpcPort string) (*App, error) {
-	db, err := database.Connect(cfg.Database.DSN())
+	nbConn, err := grpc.NewClient(cfg.GRPC.NotebookAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	if err != nil {
-		return nil, fmt.Errorf("connect db: %w", err)
+		return nil, fmt.Errorf("connect notebook service: %w", err)
+	}
+	nbClient := pbnotebook.NewNotebookServiceClient(nbConn)
+
+	notebookAdapter := runnergrpc.NewNotebookAdapter(nbClient)
+	blockAdapter := runnergrpc.NewBlockAdapter(nbClient)
+
+	runnerManager, err := container.NewManager(cfg.Runner)
+	if err != nil {
+		nbConn.Close()
+		return nil, fmt.Errorf("init runner manager: %w", err)
 	}
 
-	notebookRepo := nbpg.NewNotebookRepository(db)
-	blockRepo := nbpg.NewBlockRepository(db)
-	permRepo := nbpg.NewPermissionRepository(db)
-	notebookUC := nbusecase.New(notebookRepo, blockRepo, permRepo)
+	execSessionRepo := session_repository.NewExecutionSessionRepository(cfg.Runner.ExecutionTimeout)
+	runnerSvc := runner_service.NewRunnerService(runnerManager, execSessionRepo, notebookAdapter, blockAdapter, cfg.Runner.IdleTimeout)
+
+	reaperCtx, cancelReaper := context.WithCancel(context.Background())
+	go runnerSvc.StartIdleReaper(reaperCtx)
 
 	lis, err := net.Listen("tcp", ":"+grpcPort)
 	if err != nil {
+		cancelReaper()
+		nbConn.Close()
 		return nil, fmt.Errorf("listen: %w", err)
 	}
 
@@ -48,29 +66,37 @@ func New(cfg *config.Config, grpcPort string) (*App, error) {
 	srv := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
 			grpcutil.RecoveryUnaryInterceptor(),
-			grpcutil.MetricsUnaryInterceptor("notebook"),
+			grpcutil.MetricsUnaryInterceptor("runner"),
 			grpcutil.LoggingUnaryInterceptor(),
 		),
 	)
-	pb.RegisterNotebookServiceServer(srv, nbgrpc.NewServer(notebookUC, blockRepo))
+	pbrunner.RegisterRunnerServiceServer(srv, runnergrpc.NewServer(runnerSvc, nbClient))
 
 	return &App{
-		grpcServer: srv,
-		listener:   lis,
-		db:         db,
-		metricsSrv: metricsSrv,
+		grpcServer:    srv,
+		listener:      lis,
+		runnerManager: runnerManager,
+		cancelReaper:  cancelReaper,
+		nbConn:        nbConn,
+		metricsSrv:    metricsSrv,
 	}, nil
 }
 
 func (a *App) Run() error {
-	slog.Info("notebook service started", "addr", a.listener.Addr().String())
+	slog.Info("runner service started", "addr", a.listener.Addr().String())
 	return a.grpcServer.Serve(a.listener)
 }
 
 func (a *App) Shutdown(_ context.Context) {
 	metrics.ShutdownMetricsServer(a.metricsSrv)
+	a.cancelReaper()
 	a.grpcServer.GracefulStop()
-	if err := a.db.Close(); err != nil {
-		slog.Error("db close error", "error", err)
+	if a.runnerManager != nil {
+		if err := a.runnerManager.Close(); err != nil {
+			slog.Error("runner manager close error", "error", err)
+		}
+	}
+	if a.nbConn != nil {
+		a.nbConn.Close()
 	}
 }


### PR DESCRIPTION
## Summary
- PR #27 (email verification) случайно перезаписал `internal/runner/app/app.go` кодом notebook-сервиса, из-за чего runner-контейнер падал при старте (пытался подключиться к БД, которой у него нет)
- Восстановлен оригинальный код runner app: gRPC-клиент к Notebook Service, Docker container manager, session repository, idle reaper