### PR TITLE
fix(auth): prevent changing email to the same value

### DIFF
--- a/internal/auth/usecase/profile.go
+++ b/internal/auth/usecase/profile.go
@@ -244,6 +244,11 @@ func (uc *ProfileUsecase) ChangeEmail(ctx context.Context, userID int64, newEmai
 		return nil, domain.ErrUnauthorized
 	}
 
+	if strings.EqualFold(newEmail, user.Email) {
+		logger.Error(ctx, "usecase.profile.ChangeEmail", "error", "email unchanged")
+		return nil, fmt.Errorf("%w: email is the same as current", domain.ErrInvalidInput)
+	}
+
 	if err := httputil.ValidateEmail(newEmail); err != nil {
 		logger.Error(ctx, "usecase.profile.ChangeEmail", "error", err)
 		return nil, fmt.Errorf("%w: %s", domain.ErrInvalidInput, err.Error())

--- a/internal/auth/usecase/profile_test.go
+++ b/internal/auth/usecase/profile_test.go
@@ -447,6 +447,20 @@ func TestChangeEmail(t *testing.T) {
 			wantErr:   true,
 			errTarget: domain.ErrInvalidInput,
 		},
+		{
+			name:      "same email",
+			newEmail:  "test@example.com",
+			password:  "password123",
+			wantErr:   true,
+			errTarget: domain.ErrInvalidInput,
+		},
+		{
+			name:      "same email case insensitive",
+			newEmail:  "TEST@EXAMPLE.COM",
+			password:  "password123",
+			wantErr:   true,
+			errTarget: domain.ErrInvalidInput,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary
- Добавлена case-insensitive проверка `strings.EqualFold(newEmail, user.Email)` в usecase `ChangeEmail` (после валидации пароля, до проверки формата)
- Возвращает `domain.ErrInvalidInput` с сообщением "email is the same as current"
- Добавлены 2 тест-кейса: exact match и case-insensitive

## Test plan
- [x] `go test -v -run TestChangeEmail ./internal/auth/usecase/...` -- все 5 тестов проходят
- [ ] Ручная проверка: `PUT /api/v1/users/me/email` с текущим email -> HTTP 400

Closes frontend-park-mail-ru/2026_1_KISS#47 (minor #2)