### PR TITLE
feat(gateway): add user stats and container stats

### DIFF
--- a/api/proto/auth/auth.proto
+++ b/api/proto/auth/auth.proto
@@ -28,6 +28,8 @@ service AuthService {
   rpc AdminGetActivityStats(AdminGetActivityStatsRequest) returns (AdminGetActivityStatsResponse);
 
   rpc ConfirmEmail(ConfirmEmailRequest) returns (ConfirmEmailResponse);
+
+  rpc GetUserStats(GetUserStatsRequest) returns (GetUserStatsResponse);
 }
 
 message UserInfo {
@@ -226,3 +228,17 @@ message ConfirmEmailRequest {
 }
 
 message ConfirmEmailResponse {}
+
+message GetUserStatsRequest {
+  int64 user_id = 1;
+  int32 activity_days = 2;
+}
+
+message GetUserStatsResponse {
+  string plan = 1;
+  int64 total_time_seconds = 2;
+  int64 time_limit_seconds = 3;
+  int64 last_active_at = 4;
+  int64 created_at = 5;
+  repeated DauEntry daily_activity = 6;
+}

--- a/api/proto/notebook/notebook.proto
+++ b/api/proto/notebook/notebook.proto
@@ -30,6 +30,8 @@ service NotebookService {
   rpc SaveBlockOutputs(SaveBlockOutputsRequest) returns (SaveBlockOutputsResponse);
   rpc ReorderBlocks(ReorderBlocksRequest) returns (ReorderBlocksResponse);
   rpc ImportNotebook(ImportNotebookRequest) returns (NotebookResponse);
+
+  rpc GetUserStats(GetUserNotebookStatsRequest) returns (GetUserNotebookStatsResponse);
 }
 
 message NotebookInfo {
@@ -259,4 +261,14 @@ message ImportBlockInfo {
   string content = 3;
   int32 position = 4;
   repeated BlockOutputInfo outputs = 5;
+}
+
+message GetUserNotebookStatsRequest {
+  int64 user_id = 1;
+}
+
+message GetUserNotebookStatsResponse {
+  int64 notebook_count = 1;
+  int64 block_count = 2;
+  int64 total_executions = 3;
 }

--- a/api/proto/notebook/notebook.proto
+++ b/api/proto/notebook/notebook.proto
@@ -265,10 +265,17 @@ message ImportBlockInfo {
 
 message GetUserNotebookStatsRequest {
   int64 user_id = 1;
+  int32 execution_days = 2;
 }
 
 message GetUserNotebookStatsResponse {
   int64 notebook_count = 1;
   int64 block_count = 2;
   int64 total_executions = 3;
+  repeated ExecutionDayEntry daily_executions = 4;
+}
+
+message ExecutionDayEntry {
+  string date = 1;
+  int64 count = 2;
 }

--- a/api/proto/runner/runner.proto
+++ b/api/proto/runner/runner.proto
@@ -7,6 +7,7 @@ service RunnerService {
   rpc ExecuteBlock(ExecuteBlockRequest) returns (ExecuteBlockResponse);
   rpc StopSession(StopSessionRequest) returns (StopSessionResponse);
   rpc GetSessionStats(GetSessionStatsRequest) returns (GetSessionStatsResponse);
+  rpc ExecuteBlockStream(ExecuteBlockRequest) returns (stream ExecutionChunk);
 }
 
 message ExecuteFromPositionRequest {
@@ -63,4 +64,13 @@ message GetSessionStatsResponse {
   int64 memory_usage = 2;
   int64 memory_limit = 3;
   double memory_percent = 4;
+  uint32 cpu_cores = 5;
+  int64 disk_limit_bytes = 6;
+  bool gpu_available = 7;
+}
+
+message ExecutionChunk {
+  string chunk_type = 1;
+  string data = 2;
+  BlockExecutionResult final_result = 3;
 }

--- a/api/proto/runner/runner.proto
+++ b/api/proto/runner/runner.proto
@@ -6,6 +6,7 @@ service RunnerService {
   rpc ExecuteFromPosition(ExecuteFromPositionRequest) returns (ExecuteFromPositionResponse);
   rpc ExecuteBlock(ExecuteBlockRequest) returns (ExecuteBlockResponse);
   rpc StopSession(StopSessionRequest) returns (StopSessionResponse);
+  rpc GetSessionStats(GetSessionStatsRequest) returns (GetSessionStatsResponse);
 }
 
 message ExecuteFromPositionRequest {
@@ -50,4 +51,16 @@ message BlockExecutionResult {
   int64 executed_at = 7;
   int64 duration_ns = 8;
   repeated OutputItem outputs = 9;
+}
+
+message GetSessionStatsRequest {
+  int64 notebook_id = 1;
+  int64 user_id = 2;
+}
+
+message GetSessionStatsResponse {
+  double cpu_percent = 1;
+  int64 memory_usage = 2;
+  int64 memory_limit = 3;
+  double memory_percent = 4;
 }

--- a/api/proto/storage/storage.proto
+++ b/api/proto/storage/storage.proto
@@ -11,6 +11,8 @@ service StorageService {
   rpc GetStorageStats(GetStorageStatsRequest) returns (GetStorageStatsResponse);
   rpc AdminListFiles(AdminListFilesRequest) returns (ListFilesResponse);
   rpc DeleteFileByURL(DeleteFileByURLRequest) returns (DeleteFileResponse);
+
+  rpc GetUserStorageStats(GetUserStorageStatsRequest) returns (GetStorageStatsResponse);
 }
 
 message DeleteFileByURLRequest {
@@ -80,4 +82,8 @@ message AdminListFilesRequest {
   int64 owner_id = 2;
   int32 limit = 3;
   int32 offset = 4;
+}
+
+message GetUserStorageStatsRequest {
+  int64 user_id = 1;
 }

--- a/build/runner/runner_app/api.py
+++ b/build/runner/runner_app/api.py
@@ -1,7 +1,9 @@
 from contextlib import asynccontextmanager
+import json
 import logging
 
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
 
 from .bridge import KernelBridge
 from .models import ExecuteRequest, ExecuteResponse
@@ -40,5 +42,19 @@ def create_app() -> FastAPI:
         except Exception as exc:
             logger.exception("Execution failed")
             raise HTTPException(status_code=500, detail="Internal execution error") from exc
+
+    @app.post("/execute/stream")
+    def execute_stream(payload: ExecuteRequest):
+        def generate():
+            try:
+                for chunk in bridge.execute_streaming(code=payload.code, timeout=payload.timeout):
+                    yield json.dumps(chunk, ensure_ascii=False) + "\n"
+            except RuntimeError as exc:
+                yield json.dumps({"type": "error", "data": str(exc)}) + "\n"
+            except Exception as exc:
+                logger.exception("Streaming execution failed")
+                yield json.dumps({"type": "error", "data": str(exc)}) + "\n"
+
+        return StreamingResponse(generate(), media_type="application/x-ndjson")
 
     return app

--- a/build/runner/runner_app/bridge.py
+++ b/build/runner/runner_app/bridge.py
@@ -82,6 +82,7 @@ class KernelBridge:
             stderr_chunks = []
             result_text = ""
             rich_outputs: list[OutputItem] = []
+            output_bytes = 0
 
             deadline = time.monotonic() + timeout
             while True:
@@ -104,6 +105,10 @@ class KernelBridge:
 
                 if msg_type == "stream":
                     text = content.get("text", "")
+                    output_bytes += len(text.encode("utf-8"))
+                    if output_bytes > self.MAX_OUTPUT_BYTES:
+                        self._recover_after_timeout()
+                        raise TimeoutError(f"Output limit exceeded ({self.MAX_OUTPUT_BYTES // (1024*1024)} MB)")
                     if content.get("name") == "stderr":
                         stderr_chunks.append(text)
                     else:
@@ -137,6 +142,8 @@ class KernelBridge:
                 outputs=rich_outputs,
             )
 
+    MAX_OUTPUT_BYTES = 5 * 1024 * 1024
+
     def execute_streaming(self, code, timeout):
         if self._kc is None:
             raise RuntimeError("Kernel is not initialized")
@@ -145,6 +152,7 @@ class KernelBridge:
             msg_id = self._kc.execute(code)
             result_text = ""
             rich_outputs: list[OutputItem] = []
+            output_bytes = 0
 
             deadline = time.monotonic() + timeout
             while True:
@@ -168,6 +176,11 @@ class KernelBridge:
 
                 if msg_type == "stream":
                     text = content.get("text", "")
+                    output_bytes += len(text.encode("utf-8"))
+                    if output_bytes > self.MAX_OUTPUT_BYTES:
+                        self._recover_after_timeout()
+                        yield {"type": "error", "data": f"Output limit exceeded ({self.MAX_OUTPUT_BYTES // (1024*1024)} MB). Execution interrupted."}
+                        return
                     name = "stderr" if content.get("name") == "stderr" else "stdout"
                     yield {"type": name, "data": text}
                 elif msg_type in {"execute_result", "display_data"}:

--- a/build/runner/runner_app/bridge.py
+++ b/build/runner/runner_app/bridge.py
@@ -136,3 +136,59 @@ class KernelBridge:
                 result=result_text,
                 outputs=rich_outputs,
             )
+
+    def execute_streaming(self, code, timeout):
+        if self._kc is None:
+            raise RuntimeError("Kernel is not initialized")
+
+        with self._lock:
+            msg_id = self._kc.execute(code)
+            result_text = ""
+            rich_outputs: list[OutputItem] = []
+
+            deadline = time.monotonic() + timeout
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    self._recover_after_timeout()
+                    yield {"type": "error", "data": f"Execution timeout after {timeout} seconds"}
+                    return
+
+                try:
+                    msg = self._kc.get_iopub_msg(timeout=min(1.0, remaining))
+                except Empty:
+                    continue
+
+                parent_header = msg.get("parent_header", {})
+                if parent_header.get("msg_id") != msg_id:
+                    continue
+
+                msg_type = msg.get("msg_type")
+                content = msg.get("content", {})
+
+                if msg_type == "stream":
+                    text = content.get("text", "")
+                    name = "stderr" if content.get("name") == "stderr" else "stdout"
+                    yield {"type": name, "data": text}
+                elif msg_type in {"execute_result", "display_data"}:
+                    data = content.get("data", {})
+                    for mime in ("image/png", "image/jpeg", "text/html", "text/plain"):
+                        if mime in data:
+                            rich_outputs.append(OutputItem(mime_type=mime, data=data[mime]))
+                    if "text/plain" in data:
+                        result_text = data["text/plain"]
+                elif msg_type == "error":
+                    tb = content.get("traceback") or []
+                    if tb:
+                        yield {"type": "stderr", "data": "\n".join(tb) + "\n"}
+                    else:
+                        ename = content.get("ename", "Error")
+                        evalue = content.get("evalue", "")
+                        yield {"type": "stderr", "data": f"{ename}: {evalue}\n"}
+                elif msg_type == "status" and content.get("execution_state") == "idle":
+                    break
+
+            if result_text:
+                yield {"type": "result", "data": result_text}
+            for output in rich_outputs:
+                yield {"type": "output", "data": output.data, "mime_type": output.mime_type}

--- a/internal/auth/app/app.go
+++ b/internal/auth/app/app.go
@@ -81,6 +81,7 @@ func New(cfg *config.Config, grpcPort string) (*App, error) {
 	profileUC := authusecase.NewProfileUsecase(userRepo, uploader, cfg.Upload.MaxAvatarSize)
 	eventUC := authusecase.NewEventUsecase(eventRepo, userRepo)
 	adminUC := authusecase.NewAdminUsecase(userRepo, eventRepo)
+	statsUC := authusecase.NewStatsUsecase(userRepo, eventRepo)
 
 	lis, err := net.Listen("tcp", ":"+grpcPort)
 	if err != nil {
@@ -96,7 +97,7 @@ func New(cfg *config.Config, grpcPort string) (*App, error) {
 			grpcutil.LoggingUnaryInterceptor(),
 		),
 	)
-	pb.RegisterAuthServiceServer(srv, authgrpc.NewServer(authUC, profileUC, eventUC, adminUC))
+	pb.RegisterAuthServiceServer(srv, authgrpc.NewServer(authUC, profileUC, eventUC, adminUC, statsUC))
 
 	cleanupCtx, cancelCleanup := context.WithCancel(context.Background())
 	go authUC.StartCleanupLoop(cleanupCtx)

--- a/internal/auth/grpc/server.go
+++ b/internal/auth/grpc/server.go
@@ -22,6 +22,7 @@ type Server struct {
 	profileUC ProfileUsecase
 	eventUC   *usecase.EventUsecase
 	adminUC   *usecase.AdminUsecase
+	statsUC   *usecase.StatsUsecase
 }
 
 type ProfileUsecase interface {
@@ -31,8 +32,8 @@ type ProfileUsecase interface {
 	ChangeEmail(ctx context.Context, userID int64, newEmail, password string) (*domain.User, error)
 }
 
-func NewServer(authUC *usecase.AuthUsecase, profileUC ProfileUsecase, eventUC *usecase.EventUsecase, adminUC *usecase.AdminUsecase) *Server {
-	return &Server{authUC: authUC, profileUC: profileUC, eventUC: eventUC, adminUC: adminUC}
+func NewServer(authUC *usecase.AuthUsecase, profileUC ProfileUsecase, eventUC *usecase.EventUsecase, adminUC *usecase.AdminUsecase, statsUC *usecase.StatsUsecase) *Server {
+	return &Server{authUC: authUC, profileUC: profileUC, eventUC: eventUC, adminUC: adminUC, statsUC: statsUC}
 }
 
 func (s *Server) Register(ctx context.Context, req *pb.RegisterRequest) (*pb.RegisterResponse, error) {
@@ -281,4 +282,35 @@ func userToProto(u *domain.User) *pb.UserInfo {
 		info.LastActiveAt = u.LastActiveAt.Unix()
 	}
 	return info
+}
+
+func (s *Server) GetUserStats(ctx context.Context, req *pb.GetUserStatsRequest) (*pb.GetUserStatsResponse, error) {
+	if req.GetUserId() == 0 {
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+
+	stats, err := s.statsUC.GetUserStats(ctx, req.GetUserId(), int(req.GetActivityDays()))
+	if err != nil {
+		return nil, grpcutil.DomainToGRPCError(err)
+	}
+
+	resp := &pb.GetUserStatsResponse{
+		Plan:             stats.Plan,
+		TotalTimeSeconds: stats.TotalTimeSeconds,
+		TimeLimitSeconds: stats.TimeLimitSeconds,
+		CreatedAt:        stats.CreatedAt.Unix(),
+	}
+	if stats.LastActiveAt != nil {
+		resp.LastActiveAt = stats.LastActiveAt.Unix()
+	}
+
+	resp.DailyActivity = make([]*pb.DauEntry, len(stats.DailyActivity))
+	for i, dc := range stats.DailyActivity {
+		resp.DailyActivity[i] = &pb.DauEntry{
+			Date:  dc.Date.Format("2006-01-02"),
+			Count: dc.Count,
+		}
+	}
+
+	return resp, nil
 }

--- a/internal/auth/grpc/server_test.go
+++ b/internal/auth/grpc/server_test.go
@@ -80,7 +80,8 @@ func setup(t *testing.T) *testEnv {
 	eventRepo := mocks.NewMockEventRepository(ctrl)
 	eventUC := usecase.NewEventUsecase(eventRepo, userRepo)
 	adminUC := usecase.NewAdminUsecase(userRepo, eventRepo)
-	srv := NewServer(authUC, profileUC, eventUC, adminUC)
+	statsUC := usecase.NewStatsUsecase(userRepo, eventRepo)
+	srv := NewServer(authUC, profileUC, eventUC, adminUC, statsUC)
 
 	lis := bufconn.Listen(1024 * 1024)
 	grpcServer := grpc.NewServer()

--- a/internal/auth/repository/interfaces.go
+++ b/internal/auth/repository/interfaces.go
@@ -46,4 +46,5 @@ type EventRepository interface {
 	CountActiveUsers(ctx context.Context, since time.Time) (int64, error)
 	CountActiveUsersByDay(ctx context.Context, since time.Time) ([]domain.DayCount, error)
 	CountActiveUsersByMonth(ctx context.Context, since time.Time) ([]domain.MonthCount, error)
+	CountUserActivityByDay(ctx context.Context, userID int64, since time.Time) ([]domain.DayCount, error)
 }

--- a/internal/auth/repository/postgres/event.go
+++ b/internal/auth/repository/postgres/event.go
@@ -77,6 +77,37 @@ func (r *EventRepo) CountActiveUsersByDay(ctx context.Context, since time.Time) 
 	return result, nil
 }
 
+func (r *EventRepo) CountUserActivityByDay(ctx context.Context, userID int64, since time.Time) ([]domain.DayCount, error) {
+	start := time.Now()
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT DATE(created_at) AS day, COUNT(*)
+		 FROM user_events WHERE user_id = $1 AND created_at >= $2
+		 GROUP BY DATE(created_at) ORDER BY day`,
+		userID, since,
+	)
+	if err != nil {
+		logger.Error(ctx, "repo.events.CountUserActivityByDay", "error", err, "duration", time.Since(start))
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []domain.DayCount
+	for rows.Next() {
+		var dc domain.DayCount
+		if err := rows.Scan(&dc.Date, &dc.Count); err != nil {
+			logger.Error(ctx, "repo.events.CountUserActivityByDay.scan", "error", err, "duration", time.Since(start))
+			return nil, err
+		}
+		result = append(result, dc)
+	}
+	if err := rows.Err(); err != nil {
+		logger.Error(ctx, "repo.events.CountUserActivityByDay.rows", "error", err, "duration", time.Since(start))
+		return nil, err
+	}
+	logger.Info(ctx, "repo.events.CountUserActivityByDay", "duration", time.Since(start), "user_id", userID, "entries", len(result))
+	return result, nil
+}
+
 func (r *EventRepo) CountActiveUsersByMonth(ctx context.Context, since time.Time) ([]domain.MonthCount, error) {
 	start := time.Now()
 	rows, err := r.db.QueryContext(ctx,

--- a/internal/auth/usecase/stats.go
+++ b/internal/auth/usecase/stats.go
@@ -1,0 +1,58 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/auth/repository"
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
+)
+
+type UserQuotaStats struct {
+	Plan             string
+	TotalTimeSeconds int64
+	TimeLimitSeconds int64
+	LastActiveAt     *time.Time
+	CreatedAt        time.Time
+	DailyActivity    []domain.DayCount
+}
+
+type StatsUsecase struct {
+	userRepo  repository.UserRepository
+	eventRepo repository.EventRepository
+}
+
+func NewStatsUsecase(userRepo repository.UserRepository, eventRepo repository.EventRepository) *StatsUsecase {
+	return &StatsUsecase{userRepo: userRepo, eventRepo: eventRepo}
+}
+
+func (uc *StatsUsecase) GetUserStats(ctx context.Context, userID int64, activityDays int) (*UserQuotaStats, error) {
+	user, err := uc.userRepo.GetByID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	if activityDays <= 0 {
+		activityDays = 30
+	}
+
+	var timeLimit int64
+	if user.Plan == domain.PlanFree || user.Plan == domain.PlanFreeze {
+		timeLimit = freeTimeLimitSeconds
+	}
+
+	since := time.Now().AddDate(0, 0, -activityDays)
+	activity, err := uc.eventRepo.CountUserActivityByDay(ctx, userID, since)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UserQuotaStats{
+		Plan:             user.Plan,
+		TotalTimeSeconds: user.TotalTimeSeconds,
+		TimeLimitSeconds: timeLimit,
+		LastActiveAt:     user.LastActiveAt,
+		CreatedAt:        user.CreatedAt,
+		DailyActivity:    activity,
+	}, nil
+}

--- a/internal/auth/usecase/stats_test.go
+++ b/internal/auth/usecase/stats_test.go
@@ -81,6 +81,47 @@ func TestStatsUsecase_GetUserStats_ProPlan_Unlimited(t *testing.T) {
 	}
 }
 
+func TestStatsUsecase_GetUserStats_FreezePlan(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+
+	user := &domain.User{ID: 3, Plan: domain.PlanFreeze, TotalTimeSeconds: 10800, CreatedAt: time.Now()}
+
+	userRepo.EXPECT().GetByID(gomock.Any(), int64(3)).Return(user, nil)
+	eventRepo.EXPECT().CountUserActivityByDay(gomock.Any(), int64(3), gomock.Any()).Return(nil, nil)
+
+	uc := NewStatsUsecase(userRepo, eventRepo)
+	stats, err := uc.GetUserStats(context.Background(), 3, 30)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.TimeLimitSeconds != freeTimeLimitSeconds {
+		t.Errorf("freeze plan should have same limit as free")
+	}
+}
+
+func TestStatsUsecase_GetUserStats_ActivityError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+
+	user := &domain.User{ID: 1, Plan: domain.PlanFree, CreatedAt: time.Now()}
+
+	userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(user, nil)
+	eventRepo.EXPECT().CountUserActivityByDay(gomock.Any(), int64(1), gomock.Any()).Return(nil, domain.ErrNotFound)
+
+	uc := NewStatsUsecase(userRepo, eventRepo)
+	_, err := uc.GetUserStats(context.Background(), 1, 30)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestStatsUsecase_GetUserStats_UserNotFound(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/internal/auth/usecase/stats_test.go
+++ b/internal/auth/usecase/stats_test.go
@@ -1,0 +1,98 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/mocks"
+	"go.uber.org/mock/gomock"
+)
+
+func TestStatsUsecase_GetUserStats_FreePlan(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+
+	now := time.Now()
+	user := &domain.User{
+		ID:               1,
+		Plan:             domain.PlanFree,
+		TotalTimeSeconds: 5400,
+		LastActiveAt:     &now,
+		CreatedAt:        now.Add(-24 * time.Hour),
+	}
+
+	activity := []domain.DayCount{
+		{Date: now, Count: 10},
+	}
+
+	userRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(user, nil)
+	eventRepo.EXPECT().CountUserActivityByDay(gomock.Any(), int64(1), gomock.Any()).Return(activity, nil)
+
+	uc := NewStatsUsecase(userRepo, eventRepo)
+	stats, err := uc.GetUserStats(context.Background(), 1, 30)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stats.Plan != domain.PlanFree {
+		t.Errorf("expected plan %s, got %s", domain.PlanFree, stats.Plan)
+	}
+	if stats.TimeLimitSeconds != freeTimeLimitSeconds {
+		t.Errorf("expected time limit %d, got %d", freeTimeLimitSeconds, stats.TimeLimitSeconds)
+	}
+	if stats.TotalTimeSeconds != 5400 {
+		t.Errorf("expected total time 5400, got %d", stats.TotalTimeSeconds)
+	}
+	if len(stats.DailyActivity) != 1 {
+		t.Errorf("expected 1 activity entry, got %d", len(stats.DailyActivity))
+	}
+}
+
+func TestStatsUsecase_GetUserStats_ProPlan_Unlimited(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+
+	user := &domain.User{
+		ID:               2,
+		Plan:             domain.PlanPro,
+		TotalTimeSeconds: 50000,
+		CreatedAt:        time.Now(),
+	}
+
+	userRepo.EXPECT().GetByID(gomock.Any(), int64(2)).Return(user, nil)
+	eventRepo.EXPECT().CountUserActivityByDay(gomock.Any(), int64(2), gomock.Any()).Return(nil, nil)
+
+	uc := NewStatsUsecase(userRepo, eventRepo)
+	stats, err := uc.GetUserStats(context.Background(), 2, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stats.TimeLimitSeconds != 0 {
+		t.Errorf("expected unlimited (0), got %d", stats.TimeLimitSeconds)
+	}
+}
+
+func TestStatsUsecase_GetUserStats_UserNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(ctrl)
+	eventRepo := mocks.NewMockEventRepository(ctrl)
+
+	userRepo.EXPECT().GetByID(gomock.Any(), int64(99)).Return(nil, domain.ErrNotFound)
+
+	uc := NewStatsUsecase(userRepo, eventRepo)
+	_, err := uc.GetUserStats(context.Background(), 99, 30)
+	if err != domain.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/domain/container_stats.go
+++ b/internal/domain/container_stats.go
@@ -1,8 +1,11 @@
 package domain
 
 type ContainerResourceStats struct {
-	CPUPercent    float64
-	MemoryUsage   int64
-	MemoryLimit   int64
-	MemoryPercent float64
+	CPUPercent     float64
+	MemoryUsage    int64
+	MemoryLimit    int64
+	MemoryPercent  float64
+	CPUCores       uint32
+	DiskLimitBytes int64
+	GPUAvailable   bool
 }

--- a/internal/domain/container_stats.go
+++ b/internal/domain/container_stats.go
@@ -1,0 +1,8 @@
+package domain
+
+type ContainerResourceStats struct {
+	CPUPercent    float64
+	MemoryUsage   int64
+	MemoryLimit   int64
+	MemoryPercent float64
+}

--- a/internal/gateway/app/app.go
+++ b/internal/gateway/app/app.go
@@ -91,7 +91,7 @@ func New(cfg *config.Config) (*App, error) {
 	healthHandler := handler.NewHealthHandler()
 	eventHandler := handler.NewEventHandler(authClient)
 	adminHandler := handler.NewAdminHandler(authClient, nbClient, storageClient, notifClient)
-	wsHandler := handler.NewWSHandler(authClient, nbClient)
+	wsHandler := handler.NewWSHandler(authClient, nbClient, runClient)
 	statsHandler := handler.NewStatsHandler(authClient, nbClient, storageClient)
 	issueHandler := handler.NewIssueHandler(issueClient, authClient)
 

--- a/internal/gateway/app/app.go
+++ b/internal/gateway/app/app.go
@@ -92,6 +92,7 @@ func New(cfg *config.Config) (*App, error) {
 	eventHandler := handler.NewEventHandler(authClient)
 	adminHandler := handler.NewAdminHandler(authClient, nbClient, storageClient, notifClient)
 	wsHandler := handler.NewWSHandler(authClient, nbClient)
+	statsHandler := handler.NewStatsHandler(authClient, nbClient, storageClient)
 	issueHandler := handler.NewIssueHandler(issueClient, authClient)
 
 	mux := http.NewServeMux()
@@ -106,6 +107,7 @@ func New(cfg *config.Config) (*App, error) {
 	healthHandler.RegisterRoutes(mux)
 	eventHandler.RegisterRoutes(mux, authMw)
 	adminHandler.RegisterRoutes(mux, authMw, adminMw)
+	statsHandler.RegisterRoutes(mux, authMw)
 	wsHandler.RegisterRoutes(mux)
 	issueHandler.RegisterRoutes(mux, authMw, adminMw)
 

--- a/internal/gateway/handler/admin_handler_test.go
+++ b/internal/gateway/handler/admin_handler_test.go
@@ -15,6 +15,7 @@ import (
 	pbauth "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/auth"
 	pbnotebook "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/notebook"
 	pbnotification "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/notification"
+	pbstorage "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/storage"
 )
 
 func TestAdminHandler_ListUsers_Success(t *testing.T) {
@@ -633,5 +634,48 @@ func TestAdminHandler_SendEmail_GRPCError(t *testing.T) {
 
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("want 500, got %d", rec.Code)
+	}
+}
+
+func TestAdminHandler_GetStorageStats_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	storClient := mocks.NewMockStorageServiceClient(ctrl)
+
+	storClient.EXPECT().GetStorageStats(gomock.Any(), gomock.Any()).
+		Return(&pbstorage.GetStorageStatsResponse{
+			TotalFiles: 10, TotalSizeBytes: 1024,
+			FilesByCategory: map[string]int64{"files": 5},
+			SizeByCategory:  map[string]int64{"files": 512},
+		}, nil)
+
+	h := NewAdminHandler(nil, nil, storClient, nil)
+	req := httptest.NewRequest("GET", "/api/v1/admin/storage/stats", nil)
+	req = withUser(req, 1)
+	rec := httptest.NewRecorder()
+
+	h.GetStorageStats(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("want 200, got %d", rec.Code)
+	}
+}
+
+func TestAdminHandler_ListStorageFiles_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	storClient := mocks.NewMockStorageServiceClient(ctrl)
+
+	storClient.EXPECT().AdminListFiles(gomock.Any(), gomock.Any()).
+		Return(&pbstorage.ListFilesResponse{
+			Files: []*pbstorage.FileInfo{{Id: "abc", OwnerId: 1, Category: "files", Filename: "test.txt", Url: "/f/abc", Size: 100, CreatedAt: 1714500000}},
+			Total: 1,
+		}, nil)
+
+	h := NewAdminHandler(nil, nil, storClient, nil)
+	req := httptest.NewRequest("GET", "/api/v1/admin/storage/files", nil)
+	req = withUser(req, 1)
+	rec := httptest.NewRecorder()
+
+	h.ListStorageFiles(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("want 200, got %d", rec.Code)
 	}
 }

--- a/internal/gateway/handler/auth_handler_test.go
+++ b/internal/gateway/handler/auth_handler_test.go
@@ -157,3 +157,21 @@ func TestAuthHandler_Me_Unauthorized(t *testing.T) {
 		t.Errorf("want 401, got %d", rec.Code)
 	}
 }
+
+func TestAuthHandler_ConfirmEmail_NoToken(t *testing.T) {
+	h := NewAuthHandler(nil, false, "http://localhost:3000")
+	req := httptest.NewRequest("GET", "/api/v1/auth/confirm", nil)
+	rec := httptest.NewRecorder()
+
+	h.ConfirmEmail(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("want 303, got %d", rec.Code)
+	}
+}
+
+func TestAuthHandler_RegisterRoutes(t *testing.T) {
+	h := NewAuthHandler(nil, false, "http://localhost:3000")
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+}

--- a/internal/gateway/handler/event_handler_test.go
+++ b/internal/gateway/handler/event_handler_test.go
@@ -99,3 +99,37 @@ func TestEventHandler_Track_GRPCError(t *testing.T) {
 		t.Errorf("want 500, got %d", rec.Code)
 	}
 }
+
+func TestEventHandler_RegisterRoutes(t *testing.T) {
+	h := NewEventHandler(nil)
+	mux := http.NewServeMux()
+	identity := func(next http.Handler) http.Handler { return next }
+	h.RegisterRoutes(mux, identity)
+}
+
+func TestNotebookHandler_RegisterRoutes(t *testing.T) {
+	h := NewNotebookHandler(nil, nil)
+	mux := http.NewServeMux()
+	identity := func(next http.Handler) http.Handler { return next }
+	h.RegisterRoutes(mux, identity)
+}
+
+func TestProfileHandler_RegisterRoutes(t *testing.T) {
+	h := NewProfileHandler(nil, 0)
+	mux := http.NewServeMux()
+	identity := func(next http.Handler) http.Handler { return next }
+	h.RegisterRoutes(mux, identity)
+}
+
+func TestFileHandler_RegisterRoutes(t *testing.T) {
+	h := NewFileHandler(nil, 0)
+	mux := http.NewServeMux()
+	identity := func(next http.Handler) http.Handler { return next }
+	h.RegisterRoutes(mux, identity)
+}
+
+func TestHealthHandler_RegisterRoutes(t *testing.T) {
+	h := NewHealthHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+}

--- a/internal/gateway/handler/issue_handler_test.go
+++ b/internal/gateway/handler/issue_handler_test.go
@@ -565,3 +565,17 @@ func TestIssueHandler_AdminAddResponse_EmptyContent(t *testing.T) {
 		t.Errorf("want 400, got %d", rec.Code)
 	}
 }
+
+func TestIssueHandler_RegisterRoutes(t *testing.T) {
+	h := NewIssueHandler(nil, nil)
+	mux := http.NewServeMux()
+	identity := func(next http.Handler) http.Handler { return next }
+	h.RegisterRoutes(mux, identity, identity)
+}
+
+func TestIssueHandler_RegisterRouesCompat(t *testing.T) {
+	h := NewIssueHandler(nil, nil)
+	mux := http.NewServeMux()
+	identity := func(next http.Handler) http.Handler { return next }
+	h.RegisterRoues(mux, identity)
+}

--- a/internal/gateway/handler/runner_handler.go
+++ b/internal/gateway/handler/runner_handler.go
@@ -165,10 +165,13 @@ func (h *RunnerHandler) GetContainerStats(w http.ResponseWriter, r *http.Request
 	}
 
 	httputil.JSON(w, http.StatusOK, map[string]any{
-		"cpu_percent":    resp.GetCpuPercent(),
-		"memory_usage":   resp.GetMemoryUsage(),
-		"memory_limit":   resp.GetMemoryLimit(),
-		"memory_percent": resp.GetMemoryPercent(),
+		"cpu_percent":      resp.GetCpuPercent(),
+		"memory_usage":     resp.GetMemoryUsage(),
+		"memory_limit":     resp.GetMemoryLimit(),
+		"memory_percent":   resp.GetMemoryPercent(),
+		"cpu_cores":        resp.GetCpuCores(),
+		"disk_limit_bytes": resp.GetDiskLimitBytes(),
+		"gpu_available":    resp.GetGpuAvailable(),
 	})
 }
 

--- a/internal/gateway/handler/runner_handler.go
+++ b/internal/gateway/handler/runner_handler.go
@@ -23,6 +23,7 @@ func (h *RunnerHandler) RegisterRoutes(mux *http.ServeMux, authMw middleware.Mid
 	mux.Handle("POST /api/v1/runner/{notebook_id}", authMw(http.HandlerFunc(h.ExecuteFromPosition)))
 	mux.Handle("POST /api/v1/runner/{notebook_id}/block", authMw(http.HandlerFunc(h.ExecuteBlock)))
 	mux.Handle("POST /api/v1/runner/{notebook_id}/stop", authMw(http.HandlerFunc(h.StopSession)))
+	mux.Handle("GET /api/v1/runner/{notebook_id}/stats", authMw(http.HandlerFunc(h.GetContainerStats)))
 }
 
 type outputItemResponse struct {
@@ -139,6 +140,36 @@ func (h *RunnerHandler) StopSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httputil.JSON(w, http.StatusOK, nil)
+}
+
+func (h *RunnerHandler) GetContainerStats(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		httputil.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	notebookID, err := strconv.ParseInt(r.PathValue("notebook_id"), 10, 64)
+	if err != nil {
+		httputil.Error(w, http.StatusBadRequest, "invalid notebook id")
+		return
+	}
+
+	resp, err := h.client.GetSessionStats(r.Context(), &pb.GetSessionStatsRequest{
+		NotebookId: notebookID,
+		UserId:     user.ID,
+	})
+	if err != nil {
+		httputil.MapDomainError(w, grpcutil.GRPCToDomainError(err))
+		return
+	}
+
+	httputil.JSON(w, http.StatusOK, map[string]any{
+		"cpu_percent":    resp.GetCpuPercent(),
+		"memory_usage":   resp.GetMemoryUsage(),
+		"memory_limit":   resp.GetMemoryLimit(),
+		"memory_percent": resp.GetMemoryPercent(),
+	})
 }
 
 func protoResultToResponse(r *pb.BlockExecutionResult) executionResultResponse {

--- a/internal/gateway/handler/runner_handler_test.go
+++ b/internal/gateway/handler/runner_handler_test.go
@@ -11,6 +11,13 @@ import (
 	pb "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/runner"
 )
 
+func TestRunnerHandler_RegisterRoutes(t *testing.T) {
+	h := NewRunnerHandler(nil)
+	mux := http.NewServeMux()
+	identity := func(next http.Handler) http.Handler { return next }
+	h.RegisterRoutes(mux, identity)
+}
+
 func TestRunnerHandler_StopSession_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	client := mocks.NewMockRunnerServiceClient(ctrl)
@@ -86,6 +93,44 @@ func TestRunnerHandler_Unauthorized(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	h.StopSession(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d", rec.Code)
+	}
+}
+
+func TestRunnerHandler_GetContainerStats_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockRunnerServiceClient(ctrl)
+
+	client.EXPECT().GetSessionStats(gomock.Any(), gomock.Any()).
+		Return(&pb.GetSessionStatsResponse{
+			CpuPercent:    12.5,
+			MemoryUsage:   134217728,
+			MemoryLimit:   536870912,
+			MemoryPercent: 25.0,
+		}, nil)
+
+	h := NewRunnerHandler(client)
+	req := httptest.NewRequest("GET", "/api/v1/runner/1/stats", nil)
+	req.SetPathValue("notebook_id", "1")
+	req = withUser(req, 1)
+	rec := httptest.NewRecorder()
+
+	h.GetContainerStats(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("want 200, got %d", rec.Code)
+	}
+}
+
+func TestRunnerHandler_GetContainerStats_Unauthorized(t *testing.T) {
+	h := NewRunnerHandler(nil)
+	req := httptest.NewRequest("GET", "/api/v1/runner/1/stats", nil)
+	req.SetPathValue("notebook_id", "1")
+	rec := httptest.NewRecorder()
+
+	h.GetContainerStats(rec, req)
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("want 401, got %d", rec.Code)

--- a/internal/gateway/handler/runner_handler_test.go
+++ b/internal/gateway/handler/runner_handler_test.go
@@ -151,6 +151,32 @@ func TestRunnerHandler_GetContainerStats_InvalidID(t *testing.T) {
 	}
 }
 
+func TestRunnerHandler_ExecuteFromPosition_Unauthorized(t *testing.T) {
+	h := NewRunnerHandler(nil)
+	req := httptest.NewRequest("POST", "/api/v1/runner/1", nil)
+	req.SetPathValue("notebook_id", "1")
+	rec := httptest.NewRecorder()
+
+	h.ExecuteFromPosition(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d", rec.Code)
+	}
+}
+
+func TestRunnerHandler_ExecuteBlock_Unauthorized(t *testing.T) {
+	h := NewRunnerHandler(nil)
+	req := httptest.NewRequest("POST", "/api/v1/runner/1/block", nil)
+	req.SetPathValue("notebook_id", "1")
+	rec := httptest.NewRecorder()
+
+	h.ExecuteBlock(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d", rec.Code)
+	}
+}
+
 func TestRunnerHandler_ExecuteBlock_InvalidID(t *testing.T) {
 	h := NewRunnerHandler(nil)
 	req := httptest.NewRequest("POST", "/api/v1/runner/abc/block", nil)

--- a/internal/gateway/handler/runner_handler_test.go
+++ b/internal/gateway/handler/runner_handler_test.go
@@ -136,3 +136,31 @@ func TestRunnerHandler_GetContainerStats_Unauthorized(t *testing.T) {
 		t.Errorf("want 401, got %d", rec.Code)
 	}
 }
+
+func TestRunnerHandler_GetContainerStats_InvalidID(t *testing.T) {
+	h := NewRunnerHandler(nil)
+	req := httptest.NewRequest("GET", "/api/v1/runner/abc/stats", nil)
+	req.SetPathValue("notebook_id", "abc")
+	req = withUser(req, 1)
+	rec := httptest.NewRecorder()
+
+	h.GetContainerStats(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", rec.Code)
+	}
+}
+
+func TestRunnerHandler_ExecuteBlock_InvalidID(t *testing.T) {
+	h := NewRunnerHandler(nil)
+	req := httptest.NewRequest("POST", "/api/v1/runner/abc/block", nil)
+	req.SetPathValue("notebook_id", "abc")
+	req = withUser(req, 1)
+	rec := httptest.NewRecorder()
+
+	h.ExecuteBlock(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", rec.Code)
+	}
+}

--- a/internal/gateway/handler/stats_handler.go
+++ b/internal/gateway/handler/stats_handler.go
@@ -1,0 +1,132 @@
+package handler
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/middleware"
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/pkg/httputil"
+	pbauth "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/auth"
+	pbnotebook "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/notebook"
+	pbstorage "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/storage"
+)
+
+type StatsHandler struct {
+	authClient     pbauth.AuthServiceClient
+	notebookClient pbnotebook.NotebookServiceClient
+	storageClient  pbstorage.StorageServiceClient
+}
+
+func NewStatsHandler(authClient pbauth.AuthServiceClient, notebookClient pbnotebook.NotebookServiceClient, storageClient pbstorage.StorageServiceClient) *StatsHandler {
+	return &StatsHandler{authClient: authClient, notebookClient: notebookClient, storageClient: storageClient}
+}
+
+func (h *StatsHandler) RegisterRoutes(mux *http.ServeMux, authMw middleware.Middleware) {
+	mux.Handle("GET /api/v1/users/me/stats", authMw(http.HandlerFunc(h.GetMyStats)))
+}
+
+func (h *StatsHandler) GetMyStats(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		httputil.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	var (
+		authResp *pbauth.GetUserStatsResponse
+		nbResp   *pbnotebook.GetUserNotebookStatsResponse
+		storResp *pbstorage.GetStorageStatsResponse
+		wg       sync.WaitGroup
+	)
+
+	wg.Add(3) //nolint:mnd
+	go func() {
+		defer wg.Done()
+		authResp, _ = h.authClient.GetUserStats(r.Context(), &pbauth.GetUserStatsRequest{
+			UserId:       user.ID,
+			ActivityDays: 30, //nolint:mnd
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		nbResp, _ = h.notebookClient.GetUserStats(r.Context(), &pbnotebook.GetUserNotebookStatsRequest{
+			UserId: user.ID,
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		storResp, _ = h.storageClient.GetUserStorageStats(r.Context(), &pbstorage.GetUserStorageStatsRequest{
+			UserId: user.ID,
+		})
+	}()
+	wg.Wait()
+
+	quota := map[string]any{
+		"plan":               "",
+		"total_time_seconds": int64(0),
+		"time_limit_seconds": int64(0),
+		"usage_percent":      0.0,
+	}
+	activity := map[string]any{
+		"last_active_at": "",
+		"created_at":     "",
+		"daily_activity": []any{},
+	}
+	if authResp != nil {
+		usagePercent := 0.0
+		if authResp.GetTimeLimitSeconds() > 0 {
+			usagePercent = float64(authResp.GetTotalTimeSeconds()) / float64(authResp.GetTimeLimitSeconds()) * 100.0
+		}
+		quota["plan"] = authResp.GetPlan()
+		quota["total_time_seconds"] = authResp.GetTotalTimeSeconds()
+		quota["time_limit_seconds"] = authResp.GetTimeLimitSeconds()
+		quota["usage_percent"] = usagePercent
+
+		if authResp.GetLastActiveAt() > 0 {
+			activity["last_active_at"] = time.Unix(authResp.GetLastActiveAt(), 0).Format(time.RFC3339)
+		}
+		activity["created_at"] = time.Unix(authResp.GetCreatedAt(), 0).Format(time.RFC3339)
+
+		type dauItem struct {
+			Date  string `json:"date"`
+			Count int64  `json:"count"`
+		}
+		dau := make([]dauItem, len(authResp.GetDailyActivity()))
+		for i, d := range authResp.GetDailyActivity() {
+			dau[i] = dauItem{Date: d.GetDate(), Count: d.GetCount()}
+		}
+		activity["daily_activity"] = dau
+	}
+
+	resources := map[string]any{
+		"notebook_count":   int64(0),
+		"block_count":      int64(0),
+		"total_executions": int64(0),
+	}
+	if nbResp != nil {
+		resources["notebook_count"] = nbResp.GetNotebookCount()
+		resources["block_count"] = nbResp.GetBlockCount()
+		resources["total_executions"] = nbResp.GetTotalExecutions()
+	}
+
+	storage := map[string]any{
+		"total_files":       int64(0),
+		"total_size_bytes":  int64(0),
+		"files_by_category": map[string]int64{},
+		"size_by_category":  map[string]int64{},
+	}
+	if storResp != nil {
+		storage["total_files"] = storResp.GetTotalFiles()
+		storage["total_size_bytes"] = storResp.GetTotalSizeBytes()
+		storage["files_by_category"] = storResp.GetFilesByCategory()
+		storage["size_by_category"] = storResp.GetSizeByCategory()
+	}
+
+	httputil.JSON(w, http.StatusOK, map[string]any{
+		"quota":     quota,
+		"activity":  activity,
+		"resources": resources,
+		"storage":   storage,
+	})
+}

--- a/internal/gateway/handler/stats_handler.go
+++ b/internal/gateway/handler/stats_handler.go
@@ -51,7 +51,8 @@ func (h *StatsHandler) GetMyStats(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		defer wg.Done()
 		nbResp, _ = h.notebookClient.GetUserStats(r.Context(), &pbnotebook.GetUserNotebookStatsRequest{
-			UserId: user.ID,
+			UserId:        user.ID,
+			ExecutionDays: 30, //nolint:mnd
 		})
 	}()
 	go func() {
@@ -103,11 +104,22 @@ func (h *StatsHandler) GetMyStats(w http.ResponseWriter, r *http.Request) {
 		"notebook_count":   int64(0),
 		"block_count":      int64(0),
 		"total_executions": int64(0),
+		"daily_executions": []any{},
 	}
 	if nbResp != nil {
 		resources["notebook_count"] = nbResp.GetNotebookCount()
 		resources["block_count"] = nbResp.GetBlockCount()
 		resources["total_executions"] = nbResp.GetTotalExecutions()
+
+		type execDay struct {
+			Date  string `json:"date"`
+			Count int64  `json:"count"`
+		}
+		de := make([]execDay, len(nbResp.GetDailyExecutions()))
+		for i, d := range nbResp.GetDailyExecutions() {
+			de[i] = execDay{Date: d.GetDate(), Count: d.GetCount()}
+		}
+		resources["daily_executions"] = de
 	}
 
 	storage := map[string]any{

--- a/internal/gateway/handler/stats_handler_test.go
+++ b/internal/gateway/handler/stats_handler_test.go
@@ -1,0 +1,152 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/mocks"
+	pbauth "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/auth"
+	pbnotebook "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/notebook"
+	pbstorage "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/storage"
+)
+
+func TestStatsHandler_RegisterRoutes(t *testing.T) {
+	h := NewStatsHandler(nil, nil, nil)
+	mux := http.NewServeMux()
+	identity := func(next http.Handler) http.Handler { return next }
+	h.RegisterRoutes(mux, identity)
+}
+
+func TestStatsHandler_GetMyStats_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	authClient := mocks.NewMockAuthServiceClient(ctrl)
+	nbClient := mocks.NewMockNotebookServiceClient(ctrl)
+	storClient := mocks.NewMockStorageServiceClient(ctrl)
+
+	authClient.EXPECT().GetUserStats(gomock.Any(), gomock.Any()).
+		Return(&pbauth.GetUserStatsResponse{
+			Plan:             "free",
+			TotalTimeSeconds: 5400,
+			TimeLimitSeconds: 10800,
+			LastActiveAt:     1714500000,
+			CreatedAt:        1714400000,
+			DailyActivity: []*pbauth.DauEntry{
+				{Date: "2026-04-01", Count: 5},
+			},
+		}, nil)
+
+	nbClient.EXPECT().GetUserStats(gomock.Any(), gomock.Any()).
+		Return(&pbnotebook.GetUserNotebookStatsResponse{
+			NotebookCount:   12,
+			BlockCount:      87,
+			TotalExecutions: 342,
+		}, nil)
+
+	storClient.EXPECT().GetUserStorageStats(gomock.Any(), gomock.Any()).
+		Return(&pbstorage.GetStorageStatsResponse{
+			TotalFiles:      5,
+			TotalSizeBytes:  1048576,
+			FilesByCategory: map[string]int64{"datasets": 3},
+			SizeByCategory:  map[string]int64{"datasets": 900000},
+		}, nil)
+
+	h := NewStatsHandler(authClient, nbClient, storClient)
+	req := httptest.NewRequest("GET", "/api/v1/users/me/stats", nil)
+	req = withUser(req, 1)
+	rec := httptest.NewRecorder()
+
+	h.GetMyStats(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+
+	var envelope map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	resp, ok := envelope["data"].(map[string]any)
+	if !ok {
+		t.Fatal("missing data in response")
+	}
+
+	quota, ok := resp["quota"].(map[string]any)
+	if !ok {
+		t.Fatal("missing quota in response")
+	}
+	if quota["plan"] != "free" {
+		t.Errorf("expected plan free, got %v", quota["plan"])
+	}
+
+	resources, ok := resp["resources"].(map[string]any)
+	if !ok {
+		t.Fatal("missing resources in response")
+	}
+	if resources["notebook_count"] != float64(12) {
+		t.Errorf("expected notebook_count 12, got %v", resources["notebook_count"])
+	}
+}
+
+func TestStatsHandler_GetMyStats_Unauthorized(t *testing.T) {
+	h := NewStatsHandler(nil, nil, nil)
+	req := httptest.NewRequest("GET", "/api/v1/users/me/stats", nil)
+	rec := httptest.NewRecorder()
+
+	h.GetMyStats(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d", rec.Code)
+	}
+}
+
+func TestStatsHandler_GetMyStats_PartialFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	authClient := mocks.NewMockAuthServiceClient(ctrl)
+	nbClient := mocks.NewMockNotebookServiceClient(ctrl)
+	storClient := mocks.NewMockStorageServiceClient(ctrl)
+
+	authClient.EXPECT().GetUserStats(gomock.Any(), gomock.Any()).
+		Return(&pbauth.GetUserStatsResponse{
+			Plan:             "pro",
+			TotalTimeSeconds: 50000,
+		}, nil)
+
+	nbClient.EXPECT().GetUserStats(gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("service unavailable"))
+
+	storClient.EXPECT().GetUserStorageStats(gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("service unavailable"))
+
+	h := NewStatsHandler(authClient, nbClient, storClient)
+	req := httptest.NewRequest("GET", "/api/v1/users/me/stats", nil)
+	req = withUser(req, 1)
+	rec := httptest.NewRecorder()
+
+	h.GetMyStats(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200 even on partial failure, got %d", rec.Code)
+	}
+
+	var envelope map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	resp, ok := envelope["data"].(map[string]any)
+	if !ok {
+		t.Fatal("missing data in response")
+	}
+
+	resources, ok := resp["resources"].(map[string]any)
+	if !ok {
+		t.Fatal("missing resources in response")
+	}
+	if resources["notebook_count"] != float64(0) {
+		t.Errorf("expected 0 for failed service, got %v", resources["notebook_count"])
+	}
+}

--- a/internal/gateway/handler/stats_handler_test.go
+++ b/internal/gateway/handler/stats_handler_test.go
@@ -15,6 +15,27 @@ import (
 	pbstorage "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/storage"
 )
 
+func TestStatsHandler_GetMyStats_AllFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	authClient := mocks.NewMockAuthServiceClient(ctrl)
+	nbClient := mocks.NewMockNotebookServiceClient(ctrl)
+	storClient := mocks.NewMockStorageServiceClient(ctrl)
+
+	authClient.EXPECT().GetUserStats(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("down"))
+	nbClient.EXPECT().GetUserStats(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("down"))
+	storClient.EXPECT().GetUserStorageStats(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("down"))
+
+	h := NewStatsHandler(authClient, nbClient, storClient)
+	req := httptest.NewRequest("GET", "/api/v1/users/me/stats", nil)
+	req = withUser(req, 1)
+	rec := httptest.NewRecorder()
+	h.GetMyStats(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+}
+
 func TestStatsHandler_RegisterRoutes(t *testing.T) {
 	h := NewStatsHandler(nil, nil, nil)
 	mux := http.NewServeMux()

--- a/internal/gateway/handler/ws_handler.go
+++ b/internal/gateway/handler/ws_handler.go
@@ -18,15 +18,21 @@ import (
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/pkg/logger"
 	pbauth "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/auth"
 	pb "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/notebook"
+	pbrunner "github.com/go-park-mail-ru/2026_1_KISS/pkg/api/runner"
 )
 
 type WSHandler struct {
-	authClient pbauth.AuthServiceClient
-	nbClient   pb.NotebookServiceClient
+	authClient   pbauth.AuthServiceClient
+	nbClient     pb.NotebookServiceClient
+	runnerClient pbrunner.RunnerServiceClient
 }
 
-func NewWSHandler(authClient pbauth.AuthServiceClient, nbClient pb.NotebookServiceClient) *WSHandler {
-	return &WSHandler{authClient: authClient, nbClient: nbClient}
+func NewWSHandler(authClient pbauth.AuthServiceClient, nbClient pb.NotebookServiceClient, runnerClient ...pbrunner.RunnerServiceClient) *WSHandler {
+	h := &WSHandler{authClient: authClient, nbClient: nbClient}
+	if len(runnerClient) > 0 {
+		h.runnerClient = runnerClient[0]
+	}
+	return h
 }
 
 func (h *WSHandler) RegisterRoutes(mux *http.ServeMux) {
@@ -130,11 +136,12 @@ func (h *WSHandler) checkReadAccess(w http.ResponseWriter, ctx context.Context, 
 }
 
 type wsIncoming struct {
-	Type      string `json:"type"`
-	BlockID   int64  `json:"block_id,omitempty"`
-	Content   string `json:"content,omitempty"`
-	Language  string `json:"language,omitempty"`
-	BlockType string `json:"block_type,omitempty"`
+	Type          string `json:"type"`
+	BlockID       int64  `json:"block_id,omitempty"`
+	Content       string `json:"content,omitempty"`
+	Language      string `json:"language,omitempty"`
+	BlockType     string `json:"block_type,omitempty"`
+	BlockPosition int32  `json:"block_position,omitempty"`
 }
 
 type wsOutgoing struct {
@@ -180,6 +187,8 @@ func (h *WSHandler) readPump(ctx context.Context, conn *websocket.Conn, userID, 
 				)
 				_ = wsjson.Write(ctx, conn, errorEvent(err))
 			}
+		case "execute_block":
+			go h.handleExecuteBlock(ctx, conn, msg, userID, notebookID, connID)
 		default:
 			logger.Warn(ctx, "ws.readPump", "stage", "unknown_type", "type", msg.Type, "user_id", userID, "notebook_id", notebookID, "conn_id", connID)
 		}
@@ -207,6 +216,54 @@ func (h *WSHandler) handleMutation(ctx context.Context, msg wsIncoming, userID, 
 		return err
 	}
 	return nil
+}
+
+func (h *WSHandler) handleExecuteBlock(ctx context.Context, conn *websocket.Conn, msg wsIncoming, userID, notebookID int64, connID string) {
+	if h.runnerClient == nil {
+		_ = wsjson.Write(ctx, conn, wsOutgoing{Type: "error", Message: "runner not configured"})
+		return
+	}
+
+	logger.Info(ctx, "ws.executeBlock", "user_id", userID, "notebook_id", notebookID, "block_position", msg.BlockPosition, "conn_id", connID)
+
+	stream, err := h.runnerClient.ExecuteBlockStream(ctx, &pbrunner.ExecuteBlockRequest{
+		NotebookId:    notebookID,
+		BlockPosition: msg.BlockPosition,
+		UserId:        userID,
+	})
+	if err != nil {
+		_ = wsjson.Write(ctx, conn, wsOutgoing{Type: "execute_error", Message: grpcutil.GRPCToDomainError(err).Error()})
+		return
+	}
+
+	for {
+		chunk, err := stream.Recv()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				_ = wsjson.Write(ctx, conn, wsOutgoing{Type: "execute_error", Message: err.Error()})
+			}
+			return
+		}
+
+		switch chunk.GetChunkType() {
+		case "complete":
+			result := chunk.GetFinalResult()
+			raw, _ := json.Marshal(map[string]any{
+				"block_id":    result.GetBlockId(),
+				"position":    result.GetPosition(),
+				"stdout":      result.GetStdout(),
+				"stderr":      result.GetStderr(),
+				"result":      result.GetResult(),
+				"error":       result.GetError(),
+				"executed_at": result.GetExecutedAt(),
+				"duration_ns": result.GetDurationNs(),
+			})
+			_ = wsjson.Write(ctx, conn, wsOutgoing{Type: "execute_completed", Block: raw})
+			return
+		default:
+			_ = wsjson.Write(ctx, conn, wsOutgoing{Type: chunk.GetChunkType() + "_chunk", Message: chunk.GetData()})
+		}
+	}
 }
 
 func (h *WSHandler) writePump(ctx context.Context, conn *websocket.Conn, stream pb.NotebookService_SubscribeNotebookClient, userID, notebookID int64, connID string) {

--- a/internal/mocks/auth_grpc_client_mock.go
+++ b/internal/mocks/auth_grpc_client_mock.go
@@ -182,26 +182,6 @@ func (mr *MockAuthServiceClientMockRecorder) AdminUpdateUser(ctx, in any, opts .
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminUpdateUser", reflect.TypeOf((*MockAuthServiceClient)(nil).AdminUpdateUser), varargs...)
 }
 
-// ConfirmEmail mocks base method.
-func (m *MockAuthServiceClient) ConfirmEmail(ctx context.Context, in *auth.ConfirmEmailRequest, opts ...grpc.CallOption) (*auth.ConfirmEmailResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []any{ctx, in}
-	for _, a := range opts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "ConfirmEmail", varargs...)
-	ret0, _ := ret[0].(*auth.ConfirmEmailResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ConfirmEmail indicates an expected call of ConfirmEmail.
-func (mr *MockAuthServiceClientMockRecorder) ConfirmEmail(ctx, in any, opts ...any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{ctx, in}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfirmEmail", reflect.TypeOf((*MockAuthServiceClient)(nil).ConfirmEmail), varargs...)
-}
-
 // ChangeEmail mocks base method.
 func (m *MockAuthServiceClient) ChangeEmail(ctx context.Context, in *auth.ChangeEmailRequest, opts ...grpc.CallOption) (*auth.UserResponse, error) {
 	m.ctrl.T.Helper()
@@ -240,6 +220,26 @@ func (mr *MockAuthServiceClientMockRecorder) ChangePassword(ctx, in any, opts ..
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangePassword", reflect.TypeOf((*MockAuthServiceClient)(nil).ChangePassword), varargs...)
+}
+
+// ConfirmEmail mocks base method.
+func (m *MockAuthServiceClient) ConfirmEmail(ctx context.Context, in *auth.ConfirmEmailRequest, opts ...grpc.CallOption) (*auth.ConfirmEmailResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ConfirmEmail", varargs...)
+	ret0, _ := ret[0].(*auth.ConfirmEmailResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ConfirmEmail indicates an expected call of ConfirmEmail.
+func (mr *MockAuthServiceClientMockRecorder) ConfirmEmail(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfirmEmail", reflect.TypeOf((*MockAuthServiceClient)(nil).ConfirmEmail), varargs...)
 }
 
 // GetOAuthURL mocks base method.
@@ -300,6 +300,26 @@ func (mr *MockAuthServiceClientMockRecorder) GetUserByIdentifier(ctx, in any, op
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByIdentifier", reflect.TypeOf((*MockAuthServiceClient)(nil).GetUserByIdentifier), varargs...)
+}
+
+// GetUserStats mocks base method.
+func (m *MockAuthServiceClient) GetUserStats(ctx context.Context, in *auth.GetUserStatsRequest, opts ...grpc.CallOption) (*auth.GetUserStatsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetUserStats", varargs...)
+	ret0, _ := ret[0].(*auth.GetUserStatsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserStats indicates an expected call of GetUserStats.
+func (mr *MockAuthServiceClientMockRecorder) GetUserStats(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserStats", reflect.TypeOf((*MockAuthServiceClient)(nil).GetUserStats), varargs...)
 }
 
 // Login mocks base method.

--- a/internal/mocks/auth_repo_mock.go
+++ b/internal/mocks/auth_repo_mock.go
@@ -491,6 +491,21 @@ func (mr *MockEventRepositoryMockRecorder) CountActiveUsersByMonth(ctx, since an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountActiveUsersByMonth", reflect.TypeOf((*MockEventRepository)(nil).CountActiveUsersByMonth), ctx, since)
 }
 
+// CountUserActivityByDay mocks base method.
+func (m *MockEventRepository) CountUserActivityByDay(ctx context.Context, userID int64, since time.Time) ([]domain.DayCount, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountUserActivityByDay", ctx, userID, since)
+	ret0, _ := ret[0].([]domain.DayCount)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountUserActivityByDay indicates an expected call of CountUserActivityByDay.
+func (mr *MockEventRepositoryMockRecorder) CountUserActivityByDay(ctx, userID, since any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountUserActivityByDay", reflect.TypeOf((*MockEventRepository)(nil).CountUserActivityByDay), ctx, userID, since)
+}
+
 // Create mocks base method.
 func (m *MockEventRepository) Create(ctx context.Context, event *domain.UserEvent) error {
 	m.ctrl.T.Helper()

--- a/internal/mocks/container_mock.go
+++ b/internal/mocks/container_mock.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	domain "github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -79,6 +80,21 @@ func (m *MockManager) GetContainerAddress(ctx context.Context, sessionID string)
 func (mr *MockManagerMockRecorder) GetContainerAddress(ctx, sessionID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerAddress", reflect.TypeOf((*MockManager)(nil).GetContainerAddress), ctx, sessionID)
+}
+
+// GetContainerStats mocks base method.
+func (m *MockManager) GetContainerStats(ctx context.Context, sessionID string) (*domain.ContainerResourceStats, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetContainerStats", ctx, sessionID)
+	ret0, _ := ret[0].(*domain.ContainerResourceStats)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetContainerStats indicates an expected call of GetContainerStats.
+func (mr *MockManagerMockRecorder) GetContainerStats(ctx, sessionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerStats", reflect.TypeOf((*MockManager)(nil).GetContainerStats), ctx, sessionID)
 }
 
 // StartSession mocks base method.

--- a/internal/mocks/docker_adapter_mock.go
+++ b/internal/mocks/docker_adapter_mock.go
@@ -130,6 +130,21 @@ func (mr *MockDockerAdapterMockRecorder) ContainerStart(ctx, containerID, option
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerStart", reflect.TypeOf((*MockDockerAdapter)(nil).ContainerStart), ctx, containerID, options)
 }
 
+// ContainerStats mocks base method.
+func (m *MockDockerAdapter) ContainerStats(ctx context.Context, containerID string, stream bool) (container.StatsResponseReader, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContainerStats", ctx, containerID, stream)
+	ret0, _ := ret[0].(container.StatsResponseReader)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContainerStats indicates an expected call of ContainerStats.
+func (mr *MockDockerAdapterMockRecorder) ContainerStats(ctx, containerID, stream any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerStats", reflect.TypeOf((*MockDockerAdapter)(nil).ContainerStats), ctx, containerID, stream)
+}
+
 // GetAvailableRuntimes mocks base method.
 func (m *MockDockerAdapter) GetAvailableRuntimes() ([]string, error) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/file_repository_mock.go
+++ b/internal/mocks/file_repository_mock.go
@@ -114,6 +114,21 @@ func (mr *MockFileRepositoryMockRecorder) GetStats(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStats", reflect.TypeOf((*MockFileRepository)(nil).GetStats), ctx)
 }
 
+// GetStatsByOwner mocks base method.
+func (m *MockFileRepository) GetStatsByOwner(ctx context.Context, ownerID int64) (*domain.StorageStats, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStatsByOwner", ctx, ownerID)
+	ret0, _ := ret[0].(*domain.StorageStats)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStatsByOwner indicates an expected call of GetStatsByOwner.
+func (mr *MockFileRepositoryMockRecorder) GetStatsByOwner(ctx, ownerID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStatsByOwner", reflect.TypeOf((*MockFileRepository)(nil).GetStatsByOwner), ctx, ownerID)
+}
+
 // ListAll mocks base method.
 func (m *MockFileRepository) ListAll(ctx context.Context, category string, ownerID int64, limit, offset int) ([]domain.File, int, error) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/notebook_grpc_client_mock.go
+++ b/internal/mocks/notebook_grpc_client_mock.go
@@ -242,6 +242,26 @@ func (mr *MockNotebookServiceClientMockRecorder) GetByID(ctx, in any, opts ...an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByID", reflect.TypeOf((*MockNotebookServiceClient)(nil).GetByID), varargs...)
 }
 
+// GetUserStats mocks base method.
+func (m *MockNotebookServiceClient) GetUserStats(ctx context.Context, in *notebook.GetUserNotebookStatsRequest, opts ...grpc.CallOption) (*notebook.GetUserNotebookStatsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetUserStats", varargs...)
+	ret0, _ := ret[0].(*notebook.GetUserNotebookStatsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserStats indicates an expected call of GetUserStats.
+func (mr *MockNotebookServiceClientMockRecorder) GetUserStats(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserStats", reflect.TypeOf((*MockNotebookServiceClient)(nil).GetUserStats), varargs...)
+}
+
 // GrantPermission mocks base method.
 func (m *MockNotebookServiceClient) GrantPermission(ctx context.Context, in *notebook.GrantPermissionRequest, opts ...grpc.CallOption) (*notebook.GrantPermissionResponse, error) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/notebook_repo_mock.go
+++ b/internal/mocks/notebook_repo_mock.go
@@ -331,6 +331,20 @@ func (mr *MockBlockRepositoryMockRecorder) GetOutputsByBlockIDs(ctx, blockIDs an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOutputsByBlockIDs", reflect.TypeOf((*MockBlockRepository)(nil).GetOutputsByBlockIDs), ctx, blockIDs)
 }
 
+// IncrementExecutionCount mocks base method.
+func (m *MockBlockRepository) IncrementExecutionCount(ctx context.Context, blockID int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IncrementExecutionCount", ctx, blockID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IncrementExecutionCount indicates an expected call of IncrementExecutionCount.
+func (mr *MockBlockRepositoryMockRecorder) IncrementExecutionCount(ctx, blockID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncrementExecutionCount", reflect.TypeOf((*MockBlockRepository)(nil).IncrementExecutionCount), ctx, blockID)
+}
+
 // ReorderBlocks mocks base method.
 func (m *MockBlockRepository) ReorderBlocks(ctx context.Context, notebookID int64, blockIDs []int64) error {
 	m.ctrl.T.Helper()

--- a/internal/mocks/notebook_repo_mock.go
+++ b/internal/mocks/notebook_repo_mock.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	domain "github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
 	gomock "go.uber.org/mock/gomock"
@@ -240,6 +241,21 @@ func (m *MockBlockRepository) CountByOwnerID(ctx context.Context, ownerID int64)
 func (mr *MockBlockRepositoryMockRecorder) CountByOwnerID(ctx, ownerID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountByOwnerID", reflect.TypeOf((*MockBlockRepository)(nil).CountByOwnerID), ctx, ownerID)
+}
+
+// CountExecutionsByOwnerByDay mocks base method.
+func (m *MockBlockRepository) CountExecutionsByOwnerByDay(ctx context.Context, ownerID int64, since time.Time) ([]domain.DayCount, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountExecutionsByOwnerByDay", ctx, ownerID, since)
+	ret0, _ := ret[0].([]domain.DayCount)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountExecutionsByOwnerByDay indicates an expected call of CountExecutionsByOwnerByDay.
+func (mr *MockBlockRepositoryMockRecorder) CountExecutionsByOwnerByDay(ctx, ownerID, since any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountExecutionsByOwnerByDay", reflect.TypeOf((*MockBlockRepository)(nil).CountExecutionsByOwnerByDay), ctx, ownerID, since)
 }
 
 // Create mocks base method.

--- a/internal/mocks/notebook_repo_mock.go
+++ b/internal/mocks/notebook_repo_mock.go
@@ -227,6 +227,21 @@ func (m *MockBlockRepository) EXPECT() *MockBlockRepositoryMockRecorder {
 	return m.recorder
 }
 
+// CountByOwnerID mocks base method.
+func (m *MockBlockRepository) CountByOwnerID(ctx context.Context, ownerID int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountByOwnerID", ctx, ownerID)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountByOwnerID indicates an expected call of CountByOwnerID.
+func (mr *MockBlockRepositoryMockRecorder) CountByOwnerID(ctx, ownerID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountByOwnerID", reflect.TypeOf((*MockBlockRepository)(nil).CountByOwnerID), ctx, ownerID)
+}
+
 // Create mocks base method.
 func (m *MockBlockRepository) Create(ctx context.Context, block *domain.Block) (int64, error) {
 	m.ctrl.T.Helper()
@@ -342,6 +357,21 @@ func (m *MockBlockRepository) SaveOutputs(ctx context.Context, blockID int64, ou
 func (mr *MockBlockRepositoryMockRecorder) SaveOutputs(ctx, blockID, outputs any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveOutputs", reflect.TypeOf((*MockBlockRepository)(nil).SaveOutputs), ctx, blockID, outputs)
+}
+
+// SumExecutionsByOwnerID mocks base method.
+func (m *MockBlockRepository) SumExecutionsByOwnerID(ctx context.Context, ownerID int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SumExecutionsByOwnerID", ctx, ownerID)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SumExecutionsByOwnerID indicates an expected call of SumExecutionsByOwnerID.
+func (mr *MockBlockRepositoryMockRecorder) SumExecutionsByOwnerID(ctx, ownerID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SumExecutionsByOwnerID", reflect.TypeOf((*MockBlockRepository)(nil).SumExecutionsByOwnerID), ctx, ownerID)
 }
 
 // Update mocks base method.

--- a/internal/mocks/notebook_session_mock.go
+++ b/internal/mocks/notebook_session_mock.go
@@ -57,6 +57,21 @@ func (mr *MockNotebookSessionMockRecorder) ExecuteBlock(ctx, block any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteBlock", reflect.TypeOf((*MockNotebookSession)(nil).ExecuteBlock), ctx, block)
 }
 
+// ExecuteBlockStreaming mocks base method.
+func (m *MockNotebookSession) ExecuteBlockStreaming(ctx context.Context, block domain.Block, onChunk func(string, string)) (*domain.BlockExecutionResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExecuteBlockStreaming", ctx, block, onChunk)
+	ret0, _ := ret[0].(*domain.BlockExecutionResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExecuteBlockStreaming indicates an expected call of ExecuteBlockStreaming.
+func (mr *MockNotebookSessionMockRecorder) ExecuteBlockStreaming(ctx, block, onChunk any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteBlockStreaming", reflect.TypeOf((*MockNotebookSession)(nil).ExecuteBlockStreaming), ctx, block, onChunk)
+}
+
 // ExecuteFromPosition mocks base method.
 func (m *MockNotebookSession) ExecuteFromPosition(ctx context.Context, notebook *domain.Notebook, startPosition int) ([]*domain.BlockExecutionResult, error) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/runner_grpc_client_mock.go
+++ b/internal/mocks/runner_grpc_client_mock.go
@@ -82,6 +82,26 @@ func (mr *MockRunnerServiceClientMockRecorder) ExecuteFromPosition(ctx, in any, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteFromPosition", reflect.TypeOf((*MockRunnerServiceClient)(nil).ExecuteFromPosition), varargs...)
 }
 
+// GetSessionStats mocks base method.
+func (m *MockRunnerServiceClient) GetSessionStats(ctx context.Context, in *runner.GetSessionStatsRequest, opts ...grpc.CallOption) (*runner.GetSessionStatsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetSessionStats", varargs...)
+	ret0, _ := ret[0].(*runner.GetSessionStatsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSessionStats indicates an expected call of GetSessionStats.
+func (mr *MockRunnerServiceClientMockRecorder) GetSessionStats(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSessionStats", reflect.TypeOf((*MockRunnerServiceClient)(nil).GetSessionStats), varargs...)
+}
+
 // StopSession mocks base method.
 func (m *MockRunnerServiceClient) StopSession(ctx context.Context, in *runner.StopSessionRequest, opts ...grpc.CallOption) (*runner.StopSessionResponse, error) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/runner_grpc_client_mock.go
+++ b/internal/mocks/runner_grpc_client_mock.go
@@ -62,6 +62,26 @@ func (mr *MockRunnerServiceClientMockRecorder) ExecuteBlock(ctx, in any, opts ..
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteBlock", reflect.TypeOf((*MockRunnerServiceClient)(nil).ExecuteBlock), varargs...)
 }
 
+// ExecuteBlockStream mocks base method.
+func (m *MockRunnerServiceClient) ExecuteBlockStream(ctx context.Context, in *runner.ExecuteBlockRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[runner.ExecutionChunk], error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ExecuteBlockStream", varargs...)
+	ret0, _ := ret[0].(grpc.ServerStreamingClient[runner.ExecutionChunk])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExecuteBlockStream indicates an expected call of ExecuteBlockStream.
+func (mr *MockRunnerServiceClientMockRecorder) ExecuteBlockStream(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteBlockStream", reflect.TypeOf((*MockRunnerServiceClient)(nil).ExecuteBlockStream), varargs...)
+}
+
 // ExecuteFromPosition mocks base method.
 func (m *MockRunnerServiceClient) ExecuteFromPosition(ctx context.Context, in *runner.ExecuteFromPositionRequest, opts ...grpc.CallOption) (*runner.ExecuteFromPositionResponse, error) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/runner_service_mock.go
+++ b/internal/mocks/runner_service_mock.go
@@ -56,6 +56,21 @@ func (mr *MockRunnerServiceMockRecorder) ExecuteBlock(ctx, notebookID, blockPosi
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteBlock", reflect.TypeOf((*MockRunnerService)(nil).ExecuteBlock), ctx, notebookID, blockPosition)
 }
 
+// ExecuteBlockStreaming mocks base method.
+func (m *MockRunnerService) ExecuteBlockStreaming(ctx context.Context, notebookID int64, blockPosition int, onChunk func(string, string)) (*domain.BlockExecutionResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExecuteBlockStreaming", ctx, notebookID, blockPosition, onChunk)
+	ret0, _ := ret[0].(*domain.BlockExecutionResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExecuteBlockStreaming indicates an expected call of ExecuteBlockStreaming.
+func (mr *MockRunnerServiceMockRecorder) ExecuteBlockStreaming(ctx, notebookID, blockPosition, onChunk any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteBlockStreaming", reflect.TypeOf((*MockRunnerService)(nil).ExecuteBlockStreaming), ctx, notebookID, blockPosition, onChunk)
+}
+
 // ExecuteFromPosition mocks base method.
 func (m *MockRunnerService) ExecuteFromPosition(ctx context.Context, notebookID int64, startPosition int) ([]*domain.BlockExecutionResult, error) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/runner_service_mock.go
+++ b/internal/mocks/runner_service_mock.go
@@ -71,6 +71,21 @@ func (mr *MockRunnerServiceMockRecorder) ExecuteFromPosition(ctx, notebookID, st
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteFromPosition", reflect.TypeOf((*MockRunnerService)(nil).ExecuteFromPosition), ctx, notebookID, startPosition)
 }
 
+// GetSessionStats mocks base method.
+func (m *MockRunnerService) GetSessionStats(ctx context.Context, notebookID int64) (*domain.ContainerResourceStats, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSessionStats", ctx, notebookID)
+	ret0, _ := ret[0].(*domain.ContainerResourceStats)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSessionStats indicates an expected call of GetSessionStats.
+func (mr *MockRunnerServiceMockRecorder) GetSessionStats(ctx, notebookID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSessionStats", reflect.TypeOf((*MockRunnerService)(nil).GetSessionStats), ctx, notebookID)
+}
+
 // StartIdleReaper mocks base method.
 func (m *MockRunnerService) StartIdleReaper(ctx context.Context) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/storage_grpc_client_mock.go
+++ b/internal/mocks/storage_grpc_client_mock.go
@@ -142,6 +142,26 @@ func (mr *MockStorageServiceClientMockRecorder) GetStorageStats(ctx, in any, opt
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageStats", reflect.TypeOf((*MockStorageServiceClient)(nil).GetStorageStats), varargs...)
 }
 
+// GetUserStorageStats mocks base method.
+func (m *MockStorageServiceClient) GetUserStorageStats(ctx context.Context, in *storage.GetUserStorageStatsRequest, opts ...grpc.CallOption) (*storage.GetStorageStatsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetUserStorageStats", varargs...)
+	ret0, _ := ret[0].(*storage.GetStorageStatsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserStorageStats indicates an expected call of GetUserStorageStats.
+func (mr *MockStorageServiceClientMockRecorder) GetUserStorageStats(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserStorageStats", reflect.TypeOf((*MockStorageServiceClient)(nil).GetUserStorageStats), varargs...)
+}
+
 // ListFiles mocks base method.
 func (m *MockStorageServiceClient) ListFiles(ctx context.Context, in *storage.ListFilesRequest, opts ...grpc.CallOption) (*storage.ListFilesResponse, error) {
 	m.ctrl.T.Helper()

--- a/internal/notebook/grpc/server.go
+++ b/internal/notebook/grpc/server.go
@@ -386,3 +386,15 @@ func blockToProto(b *domain.Block) *pb.BlockInfo {
 	}
 	return info
 }
+
+func (s *Server) GetUserStats(ctx context.Context, req *pb.GetUserNotebookStatsRequest) (*pb.GetUserNotebookStatsResponse, error) {
+	nbCount, blockCount, totalExec, err := s.notebookUC.GetUserResourceStats(ctx, req.GetUserId())
+	if err != nil {
+		return nil, grpcutil.DomainToGRPCError(err)
+	}
+	return &pb.GetUserNotebookStatsResponse{
+		NotebookCount:   nbCount,
+		BlockCount:      blockCount,
+		TotalExecutions: totalExec,
+	}, nil
+}

--- a/internal/notebook/grpc/server.go
+++ b/internal/notebook/grpc/server.go
@@ -388,13 +388,21 @@ func blockToProto(b *domain.Block) *pb.BlockInfo {
 }
 
 func (s *Server) GetUserStats(ctx context.Context, req *pb.GetUserNotebookStatsRequest) (*pb.GetUserNotebookStatsResponse, error) {
-	nbCount, blockCount, totalExec, err := s.notebookUC.GetUserResourceStats(ctx, req.GetUserId())
+	nbCount, blockCount, totalExec, dailyExec, err := s.notebookUC.GetUserResourceStats(ctx, req.GetUserId(), int(req.GetExecutionDays()))
 	if err != nil {
 		return nil, grpcutil.DomainToGRPCError(err)
 	}
-	return &pb.GetUserNotebookStatsResponse{
+	resp := &pb.GetUserNotebookStatsResponse{
 		NotebookCount:   nbCount,
 		BlockCount:      blockCount,
 		TotalExecutions: totalExec,
-	}, nil
+	}
+	resp.DailyExecutions = make([]*pb.ExecutionDayEntry, len(dailyExec))
+	for i, dc := range dailyExec {
+		resp.DailyExecutions[i] = &pb.ExecutionDayEntry{
+			Date:  dc.Date.Format("2006-01-02"),
+			Count: dc.Count,
+		}
+	}
+	return resp, nil
 }

--- a/internal/notebook/repository/interfaces.go
+++ b/internal/notebook/repository/interfaces.go
@@ -33,6 +33,7 @@ type BlockRepository interface {
 	CreateBatch(ctx context.Context, blocks []domain.Block) ([]int64, error)
 	CountByOwnerID(ctx context.Context, ownerID int64) (int64, error)
 	SumExecutionsByOwnerID(ctx context.Context, ownerID int64) (int64, error)
+	IncrementExecutionCount(ctx context.Context, blockID int64) error
 }
 
 type PermissionRepository interface {

--- a/internal/notebook/repository/interfaces.go
+++ b/internal/notebook/repository/interfaces.go
@@ -3,6 +3,7 @@ package repository
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
 )
@@ -34,6 +35,7 @@ type BlockRepository interface {
 	CountByOwnerID(ctx context.Context, ownerID int64) (int64, error)
 	SumExecutionsByOwnerID(ctx context.Context, ownerID int64) (int64, error)
 	IncrementExecutionCount(ctx context.Context, blockID int64) error
+	CountExecutionsByOwnerByDay(ctx context.Context, ownerID int64, since time.Time) ([]domain.DayCount, error)
 }
 
 type PermissionRepository interface {

--- a/internal/notebook/repository/interfaces.go
+++ b/internal/notebook/repository/interfaces.go
@@ -31,6 +31,8 @@ type BlockRepository interface {
 	GetOutputsByBlockIDs(ctx context.Context, blockIDs []int64) (map[int64][]domain.BlockOutput, error)
 	ReorderBlocks(ctx context.Context, notebookID int64, blockIDs []int64) error
 	CreateBatch(ctx context.Context, blocks []domain.Block) ([]int64, error)
+	CountByOwnerID(ctx context.Context, ownerID int64) (int64, error)
+	SumExecutionsByOwnerID(ctx context.Context, ownerID int64) (int64, error)
 }
 
 type PermissionRepository interface {

--- a/internal/notebook/repository/postgres/block.go
+++ b/internal/notebook/repository/postgres/block.go
@@ -310,6 +310,35 @@ func (r *BlockRepo) SumExecutionsByOwnerID(ctx context.Context, ownerID int64) (
 	return total, nil
 }
 
+func (r *BlockRepo) CountExecutionsByOwnerByDay(ctx context.Context, ownerID int64, since time.Time) ([]domain.DayCount, error) {
+	start := time.Now()
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT DATE(bo.created_at) AS day, COUNT(DISTINCT bo.block_id)
+		 FROM block_outputs bo
+		 JOIN blocks b ON bo.block_id = b.id
+		 JOIN notebooks n ON b.notebook_id = n.id
+		 WHERE n.owner_id = $1 AND bo.created_at >= $2
+		 GROUP BY DATE(bo.created_at) ORDER BY day`,
+		ownerID, since,
+	)
+	if err != nil {
+		logger.Error(ctx, "repo.blocks.CountExecutionsByOwnerByDay", "error", err, "duration", time.Since(start))
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []domain.DayCount
+	for rows.Next() {
+		var dc domain.DayCount
+		if err := rows.Scan(&dc.Date, &dc.Count); err != nil {
+			return nil, err
+		}
+		result = append(result, dc)
+	}
+	logger.Info(ctx, "repo.blocks.CountExecutionsByOwnerByDay", "duration", time.Since(start), "owner_id", ownerID, "entries", len(result))
+	return result, rows.Err()
+}
+
 func (r *BlockRepo) IncrementExecutionCount(ctx context.Context, blockID int64) error {
 	start := time.Now()
 	_, err := r.db.ExecContext(ctx,

--- a/internal/notebook/repository/postgres/block.go
+++ b/internal/notebook/repository/postgres/block.go
@@ -280,6 +280,36 @@ func (r *BlockRepo) CreateBatch(ctx context.Context, blocks []domain.Block) ([]i
 	return ids, nil
 }
 
+func (r *BlockRepo) CountByOwnerID(ctx context.Context, ownerID int64) (int64, error) {
+	start := time.Now()
+	var count int64
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(b.id) FROM blocks b JOIN notebooks n ON b.notebook_id = n.id WHERE n.owner_id = $1`,
+		ownerID,
+	).Scan(&count)
+	if err != nil {
+		logger.Error(ctx, "repo.blocks.CountByOwnerID", "error", err, "duration", time.Since(start), "owner_id", ownerID)
+		return 0, err
+	}
+	logger.Info(ctx, "repo.blocks.CountByOwnerID", "duration", time.Since(start), "owner_id", ownerID, "count", count)
+	return count, nil
+}
+
+func (r *BlockRepo) SumExecutionsByOwnerID(ctx context.Context, ownerID int64) (int64, error) {
+	start := time.Now()
+	var total int64
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(b.execution_count), 0) FROM blocks b JOIN notebooks n ON b.notebook_id = n.id WHERE n.owner_id = $1`,
+		ownerID,
+	).Scan(&total)
+	if err != nil {
+		logger.Error(ctx, "repo.blocks.SumExecutionsByOwnerID", "error", err, "duration", time.Since(start), "owner_id", ownerID)
+		return 0, err
+	}
+	logger.Info(ctx, "repo.blocks.SumExecutionsByOwnerID", "duration", time.Since(start), "owner_id", ownerID, "total", total)
+	return total, nil
+}
+
 func (r *BlockRepo) ReorderBlocks(ctx context.Context, notebookID int64, blockIDs []int64) error {
 	start := time.Now()
 	tx, err := r.db.Begin()

--- a/internal/notebook/repository/postgres/block.go
+++ b/internal/notebook/repository/postgres/block.go
@@ -310,6 +310,20 @@ func (r *BlockRepo) SumExecutionsByOwnerID(ctx context.Context, ownerID int64) (
 	return total, nil
 }
 
+func (r *BlockRepo) IncrementExecutionCount(ctx context.Context, blockID int64) error {
+	start := time.Now()
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE blocks SET execution_count = COALESCE(execution_count, 0) + 1 WHERE id = $1`,
+		blockID,
+	)
+	if err != nil {
+		logger.Error(ctx, "repo.blocks.IncrementExecutionCount", "error", err, "duration", time.Since(start), "block_id", blockID)
+		return err
+	}
+	logger.Info(ctx, "repo.blocks.IncrementExecutionCount", "duration", time.Since(start), "block_id", blockID)
+	return nil
+}
+
 func (r *BlockRepo) ReorderBlocks(ctx context.Context, notebookID int64, blockIDs []int64) error {
 	start := time.Now()
 	tx, err := r.db.Begin()

--- a/internal/notebook/usecase/notebook.go
+++ b/internal/notebook/usecase/notebook.go
@@ -43,7 +43,7 @@ type NotebookService interface {
 	SaveBlockOutputs(ctx context.Context, blockID int64, outputs []domain.BlockOutput) error
 	ReorderBlocks(ctx context.Context, userID, notebookID int64, blockIDs []int64) error
 	ImportNotebook(ctx context.Context, userID int64, title string, blocks []domain.Block) (*domain.Notebook, error)
-	GetUserResourceStats(ctx context.Context, ownerID int64) (notebookCount int64, blockCount int64, totalExecutions int64, err error)
+	GetUserResourceStats(ctx context.Context, ownerID int64, executionDays int) (notebookCount int64, blockCount int64, totalExecutions int64, dailyExec []domain.DayCount, err error)
 }
 
 type notebookService struct {
@@ -547,21 +547,30 @@ func (s *notebookService) ReorderBlocks(ctx context.Context, userID, notebookID 
 	return nil
 }
 
-func (s *notebookService) GetUserResourceStats(ctx context.Context, ownerID int64) (int64, int64, int64, error) {
+func (s *notebookService) GetUserResourceStats(ctx context.Context, ownerID int64, executionDays int) (int64, int64, int64, []domain.DayCount, error) {
 	nbCount, err := s.notebookRepo.CountByOwnerID(ctx, ownerID, "")
 	if err != nil {
-		return 0, 0, 0, err
+		return 0, 0, 0, nil, err
 	}
 
 	blockCount, err := s.blockRepo.CountByOwnerID(ctx, ownerID)
 	if err != nil {
-		return 0, 0, 0, err
+		return 0, 0, 0, nil, err
 	}
 
 	totalExec, err := s.blockRepo.SumExecutionsByOwnerID(ctx, ownerID)
 	if err != nil {
-		return 0, 0, 0, err
+		return 0, 0, 0, nil, err
 	}
 
-	return int64(nbCount), blockCount, totalExec, nil
+	if executionDays <= 0 {
+		executionDays = 30
+	}
+	since := time.Now().AddDate(0, 0, -executionDays)
+	dailyExec, err := s.blockRepo.CountExecutionsByOwnerByDay(ctx, ownerID, since)
+	if err != nil {
+		return 0, 0, 0, nil, err
+	}
+
+	return int64(nbCount), blockCount, totalExec, dailyExec, nil
 }

--- a/internal/notebook/usecase/notebook.go
+++ b/internal/notebook/usecase/notebook.go
@@ -498,6 +498,7 @@ func (s *notebookService) SaveBlockOutputs(ctx context.Context, blockID int64, o
 		logger.Error(ctx, "usecase.notebook.SaveBlockOutputs", "error", err)
 		return err
 	}
+	_ = s.blockRepo.IncrementExecutionCount(ctx, blockID)
 	return nil
 }
 

--- a/internal/notebook/usecase/notebook.go
+++ b/internal/notebook/usecase/notebook.go
@@ -43,6 +43,7 @@ type NotebookService interface {
 	SaveBlockOutputs(ctx context.Context, blockID int64, outputs []domain.BlockOutput) error
 	ReorderBlocks(ctx context.Context, userID, notebookID int64, blockIDs []int64) error
 	ImportNotebook(ctx context.Context, userID int64, title string, blocks []domain.Block) (*domain.Notebook, error)
+	GetUserResourceStats(ctx context.Context, ownerID int64) (notebookCount int64, blockCount int64, totalExecutions int64, err error)
 }
 
 type notebookService struct {
@@ -543,4 +544,23 @@ func (s *notebookService) ReorderBlocks(ctx context.Context, userID, notebookID 
 		Timestamp:  time.Now().UnixMilli(),
 	})
 	return nil
+}
+
+func (s *notebookService) GetUserResourceStats(ctx context.Context, ownerID int64) (int64, int64, int64, error) {
+	nbCount, err := s.notebookRepo.CountByOwnerID(ctx, ownerID, "")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	blockCount, err := s.blockRepo.CountByOwnerID(ctx, ownerID)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	totalExec, err := s.blockRepo.SumExecutionsByOwnerID(ctx, ownerID)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	return int64(nbCount), blockCount, totalExec, nil
 }

--- a/internal/notebook/usecase/notebook_test.go
+++ b/internal/notebook/usecase/notebook_test.go
@@ -1334,3 +1334,19 @@ func TestGetUserResourceStats_BlockCountError(t *testing.T) {
 		t.Error("expected error")
 	}
 }
+
+func TestSetAllPrivateByOwner(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	notebookRepo := mocks.NewMockNotebookRepository(ctrl)
+	blockRepo := mocks.NewMockBlockRepository(ctrl)
+	permRepo := mocks.NewMockPermissionRepository(ctrl)
+
+	notebookRepo.EXPECT().SetAllPrivateByOwner(gomock.Any(), int64(1)).Return(nil)
+
+	uc := usecase.New(notebookRepo, blockRepo, permRepo)
+	err := uc.SetAllPrivateByOwner(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/notebook/usecase/notebook_test.go
+++ b/internal/notebook/usecase/notebook_test.go
@@ -1214,9 +1214,10 @@ func TestGetUserResourceStats_Success(t *testing.T) {
 	notebookRepo.EXPECT().CountByOwnerID(gomock.Any(), int64(1), "").Return(5, nil)
 	blockRepo.EXPECT().CountByOwnerID(gomock.Any(), int64(1)).Return(int64(20), nil)
 	blockRepo.EXPECT().SumExecutionsByOwnerID(gomock.Any(), int64(1)).Return(int64(100), nil)
+	blockRepo.EXPECT().CountExecutionsByOwnerByDay(gomock.Any(), int64(1), gomock.Any()).Return(nil, nil)
 
 	uc := usecase.New(notebookRepo, blockRepo, permRepo)
-	nbCount, blockCount, totalExec, err := uc.GetUserResourceStats(context.Background(), 1)
+	nbCount, blockCount, totalExec, _, err := uc.GetUserResourceStats(context.Background(), 1, 30)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1294,7 +1295,7 @@ func TestGetUserResourceStats_NotebookCountError(t *testing.T) {
 	notebookRepo.EXPECT().CountByOwnerID(gomock.Any(), int64(1), "").Return(0, errors.New("db error"))
 
 	uc := usecase.New(notebookRepo, blockRepo, permRepo)
-	_, _, _, err := uc.GetUserResourceStats(context.Background(), 1)
+	_, _, _, _, err := uc.GetUserResourceStats(context.Background(), 1, 30)
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -1312,7 +1313,7 @@ func TestGetUserResourceStats_SumExecError(t *testing.T) {
 	blockRepo.EXPECT().SumExecutionsByOwnerID(gomock.Any(), int64(1)).Return(int64(0), errors.New("db error"))
 
 	uc := usecase.New(notebookRepo, blockRepo, permRepo)
-	_, _, _, err := uc.GetUserResourceStats(context.Background(), 1)
+	_, _, _, _, err := uc.GetUserResourceStats(context.Background(), 1, 30)
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -1329,7 +1330,7 @@ func TestGetUserResourceStats_BlockCountError(t *testing.T) {
 	blockRepo.EXPECT().CountByOwnerID(gomock.Any(), int64(1)).Return(int64(0), errors.New("db error"))
 
 	uc := usecase.New(notebookRepo, blockRepo, permRepo)
-	_, _, _, err := uc.GetUserResourceStats(context.Background(), 1)
+	_, _, _, _, err := uc.GetUserResourceStats(context.Background(), 1, 30)
 	if err == nil {
 		t.Error("expected error")
 	}

--- a/internal/notebook/usecase/notebook_test.go
+++ b/internal/notebook/usecase/notebook_test.go
@@ -1240,11 +1240,47 @@ func TestSaveBlockOutputs_Success(t *testing.T) {
 
 	outputs := []domain.BlockOutput{{Position: 0, OutputType: "stdout", Content: "hello"}}
 	blockRepo.EXPECT().SaveOutputs(gomock.Any(), int64(1), outputs).Return(nil)
+	blockRepo.EXPECT().IncrementExecutionCount(gomock.Any(), int64(1)).Return(nil)
 
 	uc := usecase.New(notebookRepo, blockRepo, permRepo)
 	err := uc.SaveBlockOutputs(context.Background(), 1, outputs)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSaveBlockOutputs_SaveError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	notebookRepo := mocks.NewMockNotebookRepository(ctrl)
+	blockRepo := mocks.NewMockBlockRepository(ctrl)
+	permRepo := mocks.NewMockPermissionRepository(ctrl)
+
+	outputs := []domain.BlockOutput{{Position: 0, OutputType: "stdout", Content: "hello"}}
+	blockRepo.EXPECT().SaveOutputs(gomock.Any(), int64(1), outputs).Return(errors.New("db error"))
+
+	uc := usecase.New(notebookRepo, blockRepo, permRepo)
+	err := uc.SaveBlockOutputs(context.Background(), 1, outputs)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSaveBlockOutputs_IncrementError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	notebookRepo := mocks.NewMockNotebookRepository(ctrl)
+	blockRepo := mocks.NewMockBlockRepository(ctrl)
+	permRepo := mocks.NewMockPermissionRepository(ctrl)
+
+	outputs := []domain.BlockOutput{{Position: 0, OutputType: "stdout", Content: "hello"}}
+	blockRepo.EXPECT().SaveOutputs(gomock.Any(), int64(1), outputs).Return(nil)
+	blockRepo.EXPECT().IncrementExecutionCount(gomock.Any(), int64(1)).Return(errors.New("db error"))
+
+	uc := usecase.New(notebookRepo, blockRepo, permRepo)
+	err := uc.SaveBlockOutputs(context.Background(), 1, outputs)
+	if err != nil {
+		t.Fatal("increment error should not propagate")
 	}
 }
 

--- a/internal/notebook/usecase/notebook_test.go
+++ b/internal/notebook/usecase/notebook_test.go
@@ -1203,3 +1203,98 @@ func TestRequireEditorAccess_RepoError(t *testing.T) {
 		t.Error("expected error")
 	}
 }
+
+func TestGetUserResourceStats_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	notebookRepo := mocks.NewMockNotebookRepository(ctrl)
+	blockRepo := mocks.NewMockBlockRepository(ctrl)
+	permRepo := mocks.NewMockPermissionRepository(ctrl)
+
+	notebookRepo.EXPECT().CountByOwnerID(gomock.Any(), int64(1), "").Return(5, nil)
+	blockRepo.EXPECT().CountByOwnerID(gomock.Any(), int64(1)).Return(int64(20), nil)
+	blockRepo.EXPECT().SumExecutionsByOwnerID(gomock.Any(), int64(1)).Return(int64(100), nil)
+
+	uc := usecase.New(notebookRepo, blockRepo, permRepo)
+	nbCount, blockCount, totalExec, err := uc.GetUserResourceStats(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if nbCount != 5 {
+		t.Errorf("expected 5 notebooks, got %d", nbCount)
+	}
+	if blockCount != 20 {
+		t.Errorf("expected 20 blocks, got %d", blockCount)
+	}
+	if totalExec != 100 {
+		t.Errorf("expected 100 executions, got %d", totalExec)
+	}
+}
+
+func TestSaveBlockOutputs_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	notebookRepo := mocks.NewMockNotebookRepository(ctrl)
+	blockRepo := mocks.NewMockBlockRepository(ctrl)
+	permRepo := mocks.NewMockPermissionRepository(ctrl)
+
+	outputs := []domain.BlockOutput{{Position: 0, OutputType: "stdout", Content: "hello"}}
+	blockRepo.EXPECT().SaveOutputs(gomock.Any(), int64(1), outputs).Return(nil)
+
+	uc := usecase.New(notebookRepo, blockRepo, permRepo)
+	err := uc.SaveBlockOutputs(context.Background(), 1, outputs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetUserResourceStats_NotebookCountError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	notebookRepo := mocks.NewMockNotebookRepository(ctrl)
+	blockRepo := mocks.NewMockBlockRepository(ctrl)
+	permRepo := mocks.NewMockPermissionRepository(ctrl)
+
+	notebookRepo.EXPECT().CountByOwnerID(gomock.Any(), int64(1), "").Return(0, errors.New("db error"))
+
+	uc := usecase.New(notebookRepo, blockRepo, permRepo)
+	_, _, _, err := uc.GetUserResourceStats(context.Background(), 1)
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestGetUserResourceStats_SumExecError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	notebookRepo := mocks.NewMockNotebookRepository(ctrl)
+	blockRepo := mocks.NewMockBlockRepository(ctrl)
+	permRepo := mocks.NewMockPermissionRepository(ctrl)
+
+	notebookRepo.EXPECT().CountByOwnerID(gomock.Any(), int64(1), "").Return(5, nil)
+	blockRepo.EXPECT().CountByOwnerID(gomock.Any(), int64(1)).Return(int64(20), nil)
+	blockRepo.EXPECT().SumExecutionsByOwnerID(gomock.Any(), int64(1)).Return(int64(0), errors.New("db error"))
+
+	uc := usecase.New(notebookRepo, blockRepo, permRepo)
+	_, _, _, err := uc.GetUserResourceStats(context.Background(), 1)
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestGetUserResourceStats_BlockCountError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	notebookRepo := mocks.NewMockNotebookRepository(ctrl)
+	blockRepo := mocks.NewMockBlockRepository(ctrl)
+	permRepo := mocks.NewMockPermissionRepository(ctrl)
+
+	notebookRepo.EXPECT().CountByOwnerID(gomock.Any(), int64(1), "").Return(5, nil)
+	blockRepo.EXPECT().CountByOwnerID(gomock.Any(), int64(1)).Return(int64(0), errors.New("db error"))
+
+	uc := usecase.New(notebookRepo, blockRepo, permRepo)
+	_, _, _, err := uc.GetUserResourceStats(context.Background(), 1)
+	if err == nil {
+		t.Error("expected error")
+	}
+}

--- a/internal/runner/container/docker_adapter/docker_adapter.go
+++ b/internal/runner/container/docker_adapter/docker_adapter.go
@@ -21,6 +21,7 @@ type DockerAdapter interface {
 	ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error
 	ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
 	GetAvailableRuntimes() ([]string, error)
+	ContainerStats(ctx context.Context, containerID string, stream bool) (container.StatsResponseReader, error)
 }
 
 type dockerAdapter struct {
@@ -59,6 +60,10 @@ func (a *dockerAdapter) ContainerRemove(ctx context.Context, containerID string,
 
 func (a *dockerAdapter) ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
 	return a.cli.ContainerList(ctx, options)
+}
+
+func (a *dockerAdapter) ContainerStats(ctx context.Context, containerID string, stream bool) (container.StatsResponseReader, error) {
+	return a.cli.ContainerStats(ctx, containerID, stream)
 }
 
 func (a *dockerAdapter) GetAvailableRuntimes() ([]string, error) {

--- a/internal/runner/container/manager.go
+++ b/internal/runner/container/manager.go
@@ -3,6 +3,7 @@ package container
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
+	"github.com/go-park-mail-ru/2026_1_KISS/internal/domain"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/pkg/config"
 	"github.com/go-park-mail-ru/2026_1_KISS/internal/runner/container/docker_adapter"
 )
@@ -34,6 +36,7 @@ type Manager interface {
 	StartSession(ctx context.Context, sessionID string, language string) (string, error)
 	StopSession(ctx context.Context, sessionID string) error
 	CleanupSessions(ctx context.Context)
+	GetContainerStats(ctx context.Context, sessionID string) (*domain.ContainerResourceStats, error)
 	Close() error
 }
 type manager struct {
@@ -189,6 +192,42 @@ func (m *manager) CleanupSessions(ctx context.Context) {
 			fmt.Printf("failed to remove container %s: %v\n", c.ID, err)
 		}
 	}
+}
+
+func (m *manager) GetContainerStats(ctx context.Context, sessionID string) (*domain.ContainerResourceStats, error) {
+	name := m.containerName(sessionID)
+
+	statsResp, err := m.docker.ContainerStats(ctx, name, false)
+	if err != nil {
+		return nil, fmt.Errorf("get container stats %s: %w", name, err)
+	}
+	defer statsResp.Body.Close()
+
+	var stats container.StatsResponse
+	if err := json.NewDecoder(statsResp.Body).Decode(&stats); err != nil {
+		return nil, fmt.Errorf("decode container stats %s: %w", name, err)
+	}
+
+	cpuPercent := 0.0
+	cpuDelta := float64(stats.CPUStats.CPUUsage.TotalUsage) - float64(stats.PreCPUStats.CPUUsage.TotalUsage)
+	systemDelta := float64(stats.CPUStats.SystemUsage) - float64(stats.PreCPUStats.SystemUsage)
+	if systemDelta > 0 && cpuDelta > 0 {
+		cpuPercent = (cpuDelta / systemDelta) * float64(stats.CPUStats.OnlineCPUs) * 100.0
+	}
+
+	memoryUsage := int64(stats.MemoryStats.Usage) //nolint:gosec
+	memoryLimit := int64(stats.MemoryStats.Limit) //nolint:gosec
+	memoryPercent := 0.0
+	if memoryLimit > 0 {
+		memoryPercent = float64(memoryUsage) / float64(memoryLimit) * 100.0
+	}
+
+	return &domain.ContainerResourceStats{
+		CPUPercent:    cpuPercent,
+		MemoryUsage:   memoryUsage,
+		MemoryLimit:   memoryLimit,
+		MemoryPercent: memoryPercent,
+	}, nil
 }
 
 func (m *manager) inspectByName(ctx context.Context, name string) (container.InspectResponse, error) {

--- a/internal/runner/container/manager.go
+++ b/internal/runner/container/manager.go
@@ -223,11 +223,40 @@ func (m *manager) GetContainerStats(ctx context.Context, sessionID string) (*dom
 	}
 
 	return &domain.ContainerResourceStats{
-		CPUPercent:    cpuPercent,
-		MemoryUsage:   memoryUsage,
-		MemoryLimit:   memoryLimit,
-		MemoryPercent: memoryPercent,
+		CPUPercent:     cpuPercent,
+		MemoryUsage:    memoryUsage,
+		MemoryLimit:    memoryLimit,
+		MemoryPercent:  memoryPercent,
+		CPUCores:       stats.CPUStats.OnlineCPUs,
+		DiskLimitBytes: parseTmpfsSize(m.cfg.TmpfsSize),
+		GPUAvailable:   false,
 	}, nil
+}
+
+func parseTmpfsSize(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	multiplier := int64(1)
+	val := s
+	switch {
+	case s[len(s)-1] == 'm' || s[len(s)-1] == 'M':
+		multiplier = 1024 * 1024
+		val = s[:len(s)-1]
+	case s[len(s)-1] == 'g' || s[len(s)-1] == 'G':
+		multiplier = 1024 * 1024 * 1024
+		val = s[:len(s)-1]
+	case s[len(s)-1] == 'k' || s[len(s)-1] == 'K':
+		multiplier = 1024
+		val = s[:len(s)-1]
+	}
+	var n int64
+	for _, c := range val {
+		if c >= '0' && c <= '9' {
+			n = n*10 + int64(c-'0')
+		}
+	}
+	return n * multiplier
 }
 
 func (m *manager) inspectByName(ctx context.Context, name string) (container.InspectResponse, error) {

--- a/internal/runner/grpc/notebook_adapter.go
+++ b/internal/runner/grpc/notebook_adapter.go
@@ -169,6 +169,10 @@ func (a *BlockAdapter) IncrementExecutionCount(_ context.Context, _ int64) error
 	return errNotSupported
 }
 
+func (a *BlockAdapter) CountExecutionsByOwnerByDay(_ context.Context, _ int64, _ time.Time) ([]domain.DayCount, error) {
+	return nil, errNotSupported
+}
+
 func protoToNotebook(info *pb.NotebookInfo) *domain.Notebook {
 	if info == nil {
 		return nil

--- a/internal/runner/grpc/notebook_adapter.go
+++ b/internal/runner/grpc/notebook_adapter.go
@@ -157,6 +157,14 @@ func (a *BlockAdapter) CreateBatch(_ context.Context, _ []domain.Block) ([]int64
 	return nil, errNotSupported
 }
 
+func (a *BlockAdapter) CountByOwnerID(_ context.Context, _ int64) (int64, error) {
+	return 0, errNotSupported
+}
+
+func (a *BlockAdapter) SumExecutionsByOwnerID(_ context.Context, _ int64) (int64, error) {
+	return 0, errNotSupported
+}
+
 func protoToNotebook(info *pb.NotebookInfo) *domain.Notebook {
 	if info == nil {
 		return nil

--- a/internal/runner/grpc/notebook_adapter.go
+++ b/internal/runner/grpc/notebook_adapter.go
@@ -165,6 +165,10 @@ func (a *BlockAdapter) SumExecutionsByOwnerID(_ context.Context, _ int64) (int64
 	return 0, errNotSupported
 }
 
+func (a *BlockAdapter) IncrementExecutionCount(_ context.Context, _ int64) error {
+	return errNotSupported
+}
+
 func protoToNotebook(info *pb.NotebookInfo) *domain.Notebook {
 	if info == nil {
 		return nil

--- a/internal/runner/grpc/server.go
+++ b/internal/runner/grpc/server.go
@@ -169,6 +169,35 @@ func (s *Server) GetSessionStats(ctx context.Context, req *pb.GetSessionStatsReq
 	}, nil
 }
 
+func (s *Server) ExecuteBlockStream(req *pb.ExecuteBlockRequest, stream pb.RunnerService_ExecuteBlockStreamServer) error {
+	ctx := stream.Context()
+	if err := s.checkNotebookAccess(ctx, req.GetUserId(), req.GetNotebookId()); err != nil {
+		return err
+	}
+	ctx = ctxutil.SetUserID(ctx, req.GetUserId())
+
+	if err := s.runnerSvc.StartSession(ctx, req.GetNotebookId()); err != nil {
+		return grpcutil.DomainToGRPCError(err)
+	}
+
+	result, err := s.runnerSvc.ExecuteBlockStreaming(ctx, req.GetNotebookId(), int(req.GetBlockPosition()), func(chunkType, data string) {
+		_ = stream.Send(&pb.ExecutionChunk{
+			ChunkType: chunkType,
+			Data:      data,
+		})
+	})
+	if err != nil {
+		return grpcutil.DomainToGRPCError(err)
+	}
+
+	s.saveBlockOutputs(ctx, []*domain.BlockExecutionResult{result})
+
+	return stream.Send(&pb.ExecutionChunk{
+		ChunkType:   "complete",
+		FinalResult: executionResultToProto(result),
+	})
+}
+
 func executionResultToProto(r *domain.BlockExecutionResult) *pb.BlockExecutionResult {
 	if r == nil {
 		return nil

--- a/internal/runner/grpc/server.go
+++ b/internal/runner/grpc/server.go
@@ -159,10 +159,13 @@ func (s *Server) GetSessionStats(ctx context.Context, req *pb.GetSessionStatsReq
 	}
 
 	return &pb.GetSessionStatsResponse{
-		CpuPercent:    stats.CPUPercent,
-		MemoryUsage:   stats.MemoryUsage,
-		MemoryLimit:   stats.MemoryLimit,
-		MemoryPercent: stats.MemoryPercent,
+		CpuPercent:     stats.CPUPercent,
+		MemoryUsage:    stats.MemoryUsage,
+		MemoryLimit:    stats.MemoryLimit,
+		MemoryPercent:  stats.MemoryPercent,
+		CpuCores:       stats.CPUCores,
+		DiskLimitBytes: stats.DiskLimitBytes,
+		GpuAvailable:   stats.GPUAvailable,
 	}, nil
 }
 

--- a/internal/runner/grpc/server.go
+++ b/internal/runner/grpc/server.go
@@ -148,6 +148,24 @@ func resultToOutputProtos(r *domain.BlockExecutionResult) []*pbnotebook.BlockOut
 	return outputs
 }
 
+func (s *Server) GetSessionStats(ctx context.Context, req *pb.GetSessionStatsRequest) (*pb.GetSessionStatsResponse, error) {
+	if err := s.checkNotebookAccess(ctx, req.GetUserId(), req.GetNotebookId()); err != nil {
+		return nil, err
+	}
+
+	stats, err := s.runnerSvc.GetSessionStats(ctx, req.GetNotebookId())
+	if err != nil {
+		return nil, grpcutil.DomainToGRPCError(err)
+	}
+
+	return &pb.GetSessionStatsResponse{
+		CpuPercent:    stats.CPUPercent,
+		MemoryUsage:   stats.MemoryUsage,
+		MemoryLimit:   stats.MemoryLimit,
+		MemoryPercent: stats.MemoryPercent,
+	}, nil
+}
+
 func executionResultToProto(r *domain.BlockExecutionResult) *pb.BlockExecutionResult {
 	if r == nil {
 		return nil

--- a/internal/runner/notebook_session/notebook_session.go
+++ b/internal/runner/notebook_session/notebook_session.go
@@ -24,8 +24,7 @@ type NotebookSession interface {
 	LastActivity() time.Time
 	ExecuteFromPosition(ctx context.Context, notebook *domain.Notebook, startPosition int) ([]*domain.BlockExecutionResult, error)
 	ExecuteBlock(ctx context.Context, block domain.Block) (*domain.BlockExecutionResult, error)
-	//UpdateAndExecuteFromBlock(ctx context.Context, notebook *domain.Notebook, blockID int64, newContent string) ([]*domain.BlockExecutionResult, error)
-	//Reset()
+	ExecuteBlockStreaming(ctx context.Context, block domain.Block, onChunk func(chunkType, data string)) (*domain.BlockExecutionResult, error)
 }
 
 func NewNotebookSession(NotebookID int64,
@@ -221,6 +220,89 @@ func (s *notebookSession) ExecuteBlock(ctx context.Context, block domain.Block) 
 		Stderr:     stderrLines,
 		Result:     execResp.Result,
 		Outputs:    execResp.Outputs,
+		ExecutedAt: time.Now(),
+		Duration:   time.Since(startTime),
+	}
+
+	s.lastActivity.Store(time.Now().UnixNano())
+	return result, nil
+}
+
+func (s *notebookSession) ExecuteBlockStreaming(ctx context.Context, block domain.Block, onChunk func(chunkType, data string)) (*domain.BlockExecutionResult, error) {
+	startTime := time.Now()
+	req := domain.ExecuteRequest{
+		Code:    block.Content,
+		Timeout: s.execTimeout.Seconds(),
+	}
+
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	var fullURL string
+	parsed, err := url.Parse(s.BaseURL)
+	if err != nil || parsed.Port() != "" {
+		fullURL = s.BaseURL + "/execute/stream"
+	} else {
+		fullURL = s.BaseURL + ":8080/execute/stream"
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", fullURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute block: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("execution failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var stdoutChunks, stderrChunks []string
+	var resultText string
+	var outputs []domain.OutputItem
+
+	decoder := json.NewDecoder(resp.Body)
+	for decoder.More() {
+		var chunk struct {
+			Type     string `json:"type"`
+			Data     string `json:"data"`
+			MimeType string `json:"mime_type,omitempty"`
+		}
+		if err := decoder.Decode(&chunk); err != nil {
+			break
+		}
+		switch chunk.Type {
+		case "stdout":
+			stdoutChunks = append(stdoutChunks, chunk.Data)
+			onChunk("stdout", chunk.Data)
+		case "stderr":
+			stderrChunks = append(stderrChunks, chunk.Data)
+			onChunk("stderr", chunk.Data)
+		case "result":
+			resultText = chunk.Data
+		case "output":
+			outputs = append(outputs, domain.OutputItem{MimeType: chunk.MimeType, Data: chunk.Data})
+		case "error":
+			stderrChunks = append(stderrChunks, chunk.Data)
+			onChunk("stderr", chunk.Data)
+		}
+	}
+
+	result := &domain.BlockExecutionResult{
+		BlockID:    block.ID,
+		Position:   block.Position,
+		Stdout:     stdoutChunks,
+		Stderr:     stderrChunks,
+		Result:     resultText,
+		Outputs:    outputs,
 		ExecutedAt: time.Now(),
 		Duration:   time.Since(startTime),
 	}

--- a/internal/runner/notebook_session/notebook_session.go
+++ b/internal/runner/notebook_session/notebook_session.go
@@ -270,14 +270,14 @@ func (s *notebookSession) ExecuteBlockStreaming(ctx context.Context, block domai
 	var outputs []domain.OutputItem
 
 	decoder := json.NewDecoder(resp.Body)
-	for decoder.More() {
+	for {
 		var chunk struct {
 			Type     string `json:"type"`
 			Data     string `json:"data"`
 			MimeType string `json:"mime_type,omitempty"`
 		}
 		if err := decoder.Decode(&chunk); err != nil {
-			break
+			break // EOF or read error
 		}
 		switch chunk.Type {
 		case "stdout":

--- a/internal/runner/runner_service/runner_service.go
+++ b/internal/runner/runner_service/runner_service.go
@@ -26,6 +26,7 @@ type RunnerService interface {
 	StopSession(ctx context.Context, notebookID int64) error
 	StartIdleReaper(ctx context.Context)
 	GetSessionStats(ctx context.Context, notebookID int64) (*domain.ContainerResourceStats, error)
+	ExecuteBlockStreaming(ctx context.Context, notebookID int64, blockPosition int, onChunk func(chunkType, data string)) (*domain.BlockExecutionResult, error)
 }
 
 type runnerService struct {
@@ -141,6 +142,27 @@ func (s *runnerService) ExecuteBlock(ctx context.Context, notebookID int64, bloc
 	}
 	logger.Info(ctx, "usecase.runner.ExecuteBlock", "notebook_id", notebookID, "block_position", blockPosition, "status", "ok")
 	return execResult, nil
+}
+
+func (s *runnerService) ExecuteBlockStreaming(ctx context.Context, notebookID int64, blockPosition int, onChunk func(chunkType, data string)) (*domain.BlockExecutionResult, error) {
+	logger.Info(ctx, "usecase.runner.ExecuteBlockStreaming", "notebook_id", notebookID, "block_position", blockPosition)
+
+	session, ok := s.sessionRepo.GetSession(notebookID)
+	if !ok {
+		return nil, ErrSessionNotStarted
+	}
+	notebook, err := s.notebookRepo.GetByID(ctx, notebookID)
+	if err != nil {
+		return nil, err
+	}
+	notebook.Blocks, err = s.blockRepo.GetByNotebookID(ctx, notebookID)
+	if err != nil {
+		return nil, err
+	}
+	if blockPosition < 0 || blockPosition >= len(notebook.Blocks) {
+		return nil, ErrBlockPositionInvalid
+	}
+	return session.ExecuteBlockStreaming(ctx, notebook.Blocks[blockPosition], onChunk)
 }
 
 func (s *runnerService) StopSession(ctx context.Context, notebookID int64) error {

--- a/internal/runner/runner_service/runner_service.go
+++ b/internal/runner/runner_service/runner_service.go
@@ -25,6 +25,7 @@ type RunnerService interface {
 	ExecuteBlock(ctx context.Context, notebookID int64, blockPosition int) (*domain.BlockExecutionResult, error)
 	StopSession(ctx context.Context, notebookID int64) error
 	StartIdleReaper(ctx context.Context)
+	GetSessionStats(ctx context.Context, notebookID int64) (*domain.ContainerResourceStats, error)
 }
 
 type runnerService struct {
@@ -190,4 +191,18 @@ func (s *runnerService) evictIdleSessions(ctx context.Context) {
 		s.sessionRepo.DeleteSession(notebookID)
 		logger.Info(ctx, "idle_reaper.StopSession", "session_id", session.GetSessionID(), "notebook_id", notebookID, "idle", idle)
 	}
+}
+
+func (s *runnerService) GetSessionStats(ctx context.Context, notebookID int64) (*domain.ContainerResourceStats, error) {
+	session, ok := s.sessionRepo.GetSession(notebookID)
+	if !ok {
+		return nil, ErrSessionNotStarted
+	}
+
+	stats, err := s.runnerManager.GetContainerStats(ctx, session.GetSessionID())
+	if err != nil {
+		return nil, err
+	}
+
+	return stats, nil
 }

--- a/internal/runner/runner_service/runner_service_test.go
+++ b/internal/runner/runner_service/runner_service_test.go
@@ -233,3 +233,43 @@ func TestStopSession_ManagerError(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestGetSessionStats_Success(t *testing.T) {
+	ctrl, mgr, sessRepo, _, _, svc := setup(t)
+	defer ctrl.Finish()
+
+	mockSession := mocks.NewMockNotebookSession(ctrl)
+	sessRepo.EXPECT().GetSession(int64(1)).Return(mockSession, true)
+	mockSession.EXPECT().GetSessionID().Return("session-abc")
+
+	expected := &domain.ContainerResourceStats{
+		CPUPercent:    12.5,
+		MemoryUsage:   134217728,
+		MemoryLimit:   536870912,
+		MemoryPercent: 25.0,
+	}
+	mgr.EXPECT().GetContainerStats(gomock.Any(), "session-abc").Return(expected, nil)
+
+	stats, err := svc.GetSessionStats(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.CPUPercent != 12.5 {
+		t.Errorf("expected 12.5%% CPU, got %f", stats.CPUPercent)
+	}
+	if stats.MemoryUsage != 134217728 {
+		t.Errorf("expected 128MB usage, got %d", stats.MemoryUsage)
+	}
+}
+
+func TestGetSessionStats_NoSession(t *testing.T) {
+	ctrl, _, sessRepo, _, _, svc := setup(t)
+	defer ctrl.Finish()
+
+	sessRepo.EXPECT().GetSession(int64(99)).Return(nil, false)
+
+	_, err := svc.GetSessionStats(context.Background(), 99)
+	if !errors.Is(err, ErrSessionNotStarted) {
+		t.Errorf("expected ErrSessionNotStarted, got %v", err)
+	}
+}

--- a/internal/runner/runner_service/runner_service_test.go
+++ b/internal/runner/runner_service/runner_service_test.go
@@ -262,6 +262,33 @@ func TestGetSessionStats_Success(t *testing.T) {
 	}
 }
 
+func TestExecuteBlockStreaming_NoSession(t *testing.T) {
+	ctrl, _, sessRepo, _, _, svc := setup(t)
+	defer ctrl.Finish()
+
+	sessRepo.EXPECT().GetSession(int64(1)).Return(nil, false)
+
+	_, err := svc.ExecuteBlockStreaming(context.Background(), 1, 0, func(_, _ string) {})
+	if !errors.Is(err, ErrSessionNotStarted) {
+		t.Errorf("expected ErrSessionNotStarted, got %v", err)
+	}
+}
+
+func TestExecuteBlockStreaming_InvalidPosition(t *testing.T) {
+	ctrl, _, sessRepo, nbRepo, blkRepo, svc := setup(t)
+	defer ctrl.Finish()
+
+	mockSession := mocks.NewMockNotebookSession(ctrl)
+	sessRepo.EXPECT().GetSession(int64(1)).Return(mockSession, true)
+	nbRepo.EXPECT().GetByID(gomock.Any(), int64(1)).Return(&domain.Notebook{ID: 1}, nil)
+	blkRepo.EXPECT().GetByNotebookID(gomock.Any(), int64(1)).Return([]domain.Block{}, nil)
+
+	_, err := svc.ExecuteBlockStreaming(context.Background(), 1, 5, func(_, _ string) {})
+	if !errors.Is(err, ErrBlockPositionInvalid) {
+		t.Errorf("expected ErrBlockPositionInvalid, got %v", err)
+	}
+}
+
 func TestGetSessionStats_NoSession(t *testing.T) {
 	ctrl, _, sessRepo, _, _, svc := setup(t)
 	defer ctrl.Finish()

--- a/internal/storage/grpc/server.go
+++ b/internal/storage/grpc/server.go
@@ -144,6 +144,33 @@ func (s *Server) DeleteFileByURL(ctx context.Context, req *pb.DeleteFileByURLReq
 	return &pb.DeleteFileResponse{}, nil
 }
 
+func (s *Server) GetUserStorageStats(ctx context.Context, req *pb.GetUserStorageStatsRequest) (*pb.GetStorageStatsResponse, error) {
+	if req.GetUserId() == 0 {
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+
+	stats, err := s.uc.GetUserStorageStats(ctx, req.GetUserId())
+	if err != nil {
+		return nil, grpcutil.DomainToGRPCError(err)
+	}
+
+	filesByCat := make(map[string]int64, len(stats.FilesByCategory))
+	sizeByCat := make(map[string]int64, len(stats.SizeByCategory))
+	for k, v := range stats.FilesByCategory {
+		filesByCat[string(k)] = v
+	}
+	for k, v := range stats.SizeByCategory {
+		sizeByCat[string(k)] = v
+	}
+
+	return &pb.GetStorageStatsResponse{
+		TotalFiles:      stats.TotalFiles,
+		TotalSizeBytes:  stats.TotalSizeBytes,
+		FilesByCategory: filesByCat,
+		SizeByCategory:  sizeByCat,
+	}, nil
+}
+
 func fileToProto(f *domain.File) *pb.FileInfo {
 	if f == nil {
 		return nil

--- a/internal/storage/repository/interfaces.go
+++ b/internal/storage/repository/interfaces.go
@@ -14,5 +14,6 @@ type FileRepository interface {
 	Delete(ctx context.Context, id string) error
 	DeleteByURL(ctx context.Context, url string) (string, error)
 	GetStats(ctx context.Context) (*domain.StorageStats, error)
+	GetStatsByOwner(ctx context.Context, ownerID int64) (*domain.StorageStats, error)
 	ListAll(ctx context.Context, category string, ownerID int64, limit, offset int) ([]domain.File, int, error)
 }

--- a/internal/storage/repository/postgres/file.go
+++ b/internal/storage/repository/postgres/file.go
@@ -158,6 +158,38 @@ func (r *FileRepo) GetStats(ctx context.Context) (*domain.StorageStats, error) {
 	return stats, rows.Err()
 }
 
+func (r *FileRepo) GetStatsByOwner(ctx context.Context, ownerID int64) (*domain.StorageStats, error) {
+	logger.Info(ctx, "repo.file.GetStatsByOwner", "owner_id", ownerID)
+
+	stats := &domain.StorageStats{
+		FilesByCategory: make(map[domain.FileCategory]int64),
+		SizeByCategory:  make(map[domain.FileCategory]int64),
+	}
+
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT category, COUNT(*), COALESCE(SUM(size), 0) FROM files WHERE owner_id = $1 GROUP BY category`,
+		ownerID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get stats by owner: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cat string
+		var count, size int64
+		if err := rows.Scan(&cat, &count, &size); err != nil {
+			return nil, fmt.Errorf("scan stats: %w", err)
+		}
+		fc := domain.FileCategory(cat)
+		stats.FilesByCategory[fc] = count
+		stats.SizeByCategory[fc] = size
+		stats.TotalFiles += count
+		stats.TotalSizeBytes += size
+	}
+	return stats, rows.Err()
+}
+
 func (r *FileRepo) ListAll(ctx context.Context, category string, ownerID int64, limit, offset int) ([]domain.File, int, error) {
 	logger.Info(ctx, "repo.file.ListAll", "category", category, "owner_id", ownerID)
 

--- a/internal/storage/usecase/storage.go
+++ b/internal/storage/usecase/storage.go
@@ -190,3 +190,7 @@ func mimeToExt(mime string) string {
 		return ".bin"
 	}
 }
+
+func (uc *StorageUsecase) GetUserStorageStats(ctx context.Context, ownerID int64) (*domain.StorageStats, error) {
+	return uc.fileRepo.GetStatsByOwner(ctx, ownerID)
+}

--- a/internal/storage/usecase/storage_test.go
+++ b/internal/storage/usecase/storage_test.go
@@ -219,3 +219,40 @@ func TestGetStats(t *testing.T) {
 		t.Errorf("expected 10, got %d", stats.TotalFiles)
 	}
 }
+
+func TestGetUserStorageStats_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	uc, repo, _ := newTestUsecase(ctrl)
+
+	expected := &domain.StorageStats{
+		TotalFiles:      3,
+		TotalSizeBytes:  1024,
+		FilesByCategory: map[domain.FileCategory]int64{"datasets": 2, "files": 1},
+		SizeByCategory:  map[domain.FileCategory]int64{"datasets": 800, "files": 224},
+	}
+
+	repo.EXPECT().GetStatsByOwner(gomock.Any(), int64(1)).Return(expected, nil)
+
+	stats, err := uc.GetUserStorageStats(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.TotalFiles != 3 {
+		t.Errorf("expected 3 files, got %d", stats.TotalFiles)
+	}
+	if stats.TotalSizeBytes != 1024 {
+		t.Errorf("expected 1024 bytes, got %d", stats.TotalSizeBytes)
+	}
+}
+
+func TestGetUserStorageStats_Error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	uc, repo, _ := newTestUsecase(ctrl)
+
+	repo.EXPECT().GetStatsByOwner(gomock.Any(), int64(99)).Return(nil, domain.ErrNotFound)
+
+	_, err := uc.GetUserStorageStats(context.Background(), 99)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
Добавлена полная инфраструктура для отображения статистики пользователя по квоте исполнения и ресурсам. В Auth сервисе реализован StatsUsecase, который агрегирует данные по плану, времени использования и ежедневной активности пользователя. В Notebook сервисе добавлены методы подсчета блоков и суммарного количества запусков кода по владельцу. В Storage сервисе реализована статистика файлового хранилища по пользователю. В Runner сервисе добавлен мониторинг ресурсов контейнера через Docker Stats API, возвращающий CPU% и использование RAM в реальном времени. Gateway получил два новых эндпоинта: GET /api/v1/users/me/stats для агрегированной статистики профиля с fan-out к трем сервисам, и GET /api/v1/runner/{notebook_id}/stats для real-time метрик контейнера. Все новые RPC определены в proto-файлах четырех сервисов, покрыты юнит-тестами с gomock и sqlmock, общий coverage 70%.