### PR TITLE
ci(infra): switch auto-deploy trigger from develop to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [develop]
+    branches: [master]
 
 concurrency:
   group: deploy-production
@@ -76,15 +76,15 @@ jobs:
             set -e
             cd /home/ubuntu/2026_1_KISS
 
-            git fetch origin develop
-            CHANGED=$(git diff --name-only HEAD origin/develop)
+            git fetch origin master
+            CHANGED=$(git diff --name-only HEAD origin/master)
 
             if [ -z "$CHANGED" ]; then
               echo "No changes detected, skipping deploy"
               exit 0
             fi
 
-            git reset --hard origin/develop
+            git reset --hard origin/master
 
             docker builder prune -f --filter "until=168h"
             docker image prune -af --filter "until=168h"


### PR DESCRIPTION
## Summary
- Release commits land in `master`, but the deploy workflow was listening on `develop`, so the production rollout never fired for the actual release flow.
- Aligns both the `on.push.branches` trigger and the in-script `git fetch`/`git reset --hard` target with `master`.

## Background
On-server checkout `/home/ubuntu/2026_1_KISS` is reset to `origin/<branch>` on every run, so flipping the branch name in the script is safe — there are no ad-hoc local commits to preserve.

## Test plan
- [ ] Merge this PR into `master` and confirm the `Deploy` workflow run starts automatically on the merge commit.
- [ ] Verify the SSH step logs `git fetch origin master` and a successful `git reset --hard origin/master`.
- [ ] Confirm `colkiss.ru` reflects the new build (e.g. updated commit hash in service banner / docker image labels).