### PR TITLE
fix(auth): unblock oauth providers and surface vkid errors

### DIFF
--- a/api/proto/auth/auth.proto
+++ b/api/proto/auth/auth.proto
@@ -160,6 +160,7 @@ message OAuthCallbackRequest {
   string provider = 1;
   string code = 2;
   string state = 3;
+  string device_id = 4;
 }
 
 message TrackEventRequest {

--- a/internal/auth/grpc/server.go
+++ b/internal/auth/grpc/server.go
@@ -67,7 +67,7 @@ func (s *Server) OAuthCallback(ctx context.Context, req *pb.OAuthCallbackRequest
 	if req.GetProvider() == "" || req.GetCode() == "" || req.GetState() == "" {
 		return nil, status.Error(codes.InvalidArgument, "provider, code, state are required")
 	}
-	session, user, err := s.oauthUC.Callback(ctx, req.GetProvider(), req.GetCode(), req.GetState())
+	session, user, err := s.oauthUC.Callback(ctx, req.GetProvider(), req.GetCode(), req.GetState(), req.GetDeviceId())
 	if err != nil {
 		return nil, grpcutil.DomainToGRPCError(err)
 	}

--- a/internal/auth/provider/google.go
+++ b/internal/auth/provider/google.go
@@ -60,7 +60,7 @@ func (p *GoogleProvider) AuthorizationURL(state, codeChallenge string) string {
 	return p.authURL + "?" + q.Encode()
 }
 
-func (p *GoogleProvider) Exchange(ctx context.Context, code, codeVerifier string) (*domain.ExternalUserInfo, error) {
+func (p *GoogleProvider) Exchange(ctx context.Context, code, codeVerifier, _ string) (*domain.ExternalUserInfo, error) {
 	form := url.Values{}
 	form.Set("client_id", p.clientID)
 	form.Set("client_secret", p.clientSecret)

--- a/internal/auth/provider/google_test.go
+++ b/internal/auth/provider/google_test.go
@@ -61,7 +61,7 @@ func TestGoogleProvider_Exchange_Success(t *testing.T) {
 	})
 	p, _ := newGoogleTestProvider(t, mux)
 
-	info, err := p.Exchange(context.Background(), "the-code", "the-verifier")
+	info, err := p.Exchange(context.Background(), "the-code", "the-verifier", "")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestGoogleProvider_Exchange_TokenError(t *testing.T) {
 	})
 	p, _ := newGoogleTestProvider(t, mux)
 
-	if _, err := p.Exchange(context.Background(), "x", "y"); err == nil {
+	if _, err := p.Exchange(context.Background(), "x", "y", ""); err == nil {
 		t.Fatalf("expected error on bad token response")
 	}
 }

--- a/internal/auth/provider/oauth.go
+++ b/internal/auth/provider/oauth.go
@@ -9,5 +9,5 @@ import (
 type OAuthProvider interface {
 	Name() string
 	AuthorizationURL(state, codeChallenge string) string
-	Exchange(ctx context.Context, code, codeVerifier string) (*domain.ExternalUserInfo, error)
+	Exchange(ctx context.Context, code, codeVerifier, deviceID string) (*domain.ExternalUserInfo, error)
 }

--- a/internal/auth/provider/vkid.go
+++ b/internal/auth/provider/vkid.go
@@ -59,7 +59,7 @@ func (p *VKIDProvider) AuthorizationURL(state, codeChallenge string) string {
 	return p.authURL + "?" + q.Encode()
 }
 
-func (p *VKIDProvider) Exchange(ctx context.Context, code, codeVerifier string) (*domain.ExternalUserInfo, error) {
+func (p *VKIDProvider) Exchange(ctx context.Context, code, codeVerifier, deviceID string) (*domain.ExternalUserInfo, error) {
 	form := url.Values{}
 	form.Set("client_id", p.clientID)
 	form.Set("client_secret", p.clientSecret)
@@ -67,6 +67,9 @@ func (p *VKIDProvider) Exchange(ctx context.Context, code, codeVerifier string) 
 	form.Set("code_verifier", codeVerifier)
 	form.Set("grant_type", "authorization_code")
 	form.Set("redirect_uri", p.redirectURL)
+	if deviceID != "" {
+		form.Set("device_id", deviceID)
+	}
 
 	tokenReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
@@ -85,15 +88,19 @@ func (p *VKIDProvider) Exchange(ctx context.Context, code, codeVerifier string) 
 		return nil, fmt.Errorf("vkid token exchange: status %d: %s", tokenResp.StatusCode, string(body))
 	}
 
+	tokenBody, err := io.ReadAll(io.LimitReader(tokenResp.Body, 4096))
+	if err != nil {
+		return nil, fmt.Errorf("vkid read token body: %w", err)
+	}
 	var token struct {
 		AccessToken string `json:"access_token"`
 		UserID      int64  `json:"user_id"`
 	}
-	if err := json.NewDecoder(tokenResp.Body).Decode(&token); err != nil {
-		return nil, fmt.Errorf("vkid decode token: %w", err)
+	if err := json.Unmarshal(tokenBody, &token); err != nil {
+		return nil, fmt.Errorf("vkid decode token: %w (body=%s)", err, string(tokenBody))
 	}
 	if token.AccessToken == "" {
-		return nil, fmt.Errorf("vkid token exchange: empty access_token")
+		return nil, fmt.Errorf("vkid token exchange: empty access_token (body=%s)", string(tokenBody))
 	}
 
 	infoForm := url.Values{}
@@ -116,6 +123,10 @@ func (p *VKIDProvider) Exchange(ctx context.Context, code, codeVerifier string) 
 		return nil, fmt.Errorf("vkid userinfo: status %d: %s", infoResp.StatusCode, string(body))
 	}
 
+	infoBody, err := io.ReadAll(io.LimitReader(infoResp.Body, 4096))
+	if err != nil {
+		return nil, fmt.Errorf("vkid read userinfo body: %w", err)
+	}
 	var info struct {
 		User struct {
 			UserID    string `json:"user_id"`
@@ -125,8 +136,8 @@ func (p *VKIDProvider) Exchange(ctx context.Context, code, codeVerifier string) 
 			Avatar    string `json:"avatar"`
 		} `json:"user"`
 	}
-	if err := json.NewDecoder(infoResp.Body).Decode(&info); err != nil {
-		return nil, fmt.Errorf("vkid decode userinfo: %w", err)
+	if err := json.Unmarshal(infoBody, &info); err != nil {
+		return nil, fmt.Errorf("vkid decode userinfo: %w (body=%s)", err, string(infoBody))
 	}
 
 	providerID := info.User.UserID

--- a/internal/auth/provider/vkid_test.go
+++ b/internal/auth/provider/vkid_test.go
@@ -45,7 +45,7 @@ func TestVKIDProvider_Exchange_Success(t *testing.T) {
 	})
 	p, _ := newVKIDTestProvider(t, mux)
 
-	info, err := p.Exchange(context.Background(), "c", "v")
+	info, err := p.Exchange(context.Background(), "c", "v", "")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -64,12 +64,51 @@ func TestVKIDProvider_Exchange_NoEmail(t *testing.T) {
 	})
 	p, _ := newVKIDTestProvider(t, mux)
 
-	info, err := p.Exchange(context.Background(), "c", "v")
+	info, err := p.Exchange(context.Background(), "c", "v", "")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
 	if info.Email != "" || info.EmailVerified {
 		t.Errorf("expected empty unverified email, got %+v", info)
+	}
+}
+
+func TestVKIDProvider_Exchange_EmptyAccessTokenDumpsBody(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"error":"invalid_request","error_description":"missing device_id"}`))
+	})
+	p, _ := newVKIDTestProvider(t, mux)
+
+	_, err := p.Exchange(context.Background(), "c", "v", "")
+	if err == nil {
+		t.Fatal("expected error on empty access_token")
+	}
+	if !strings.Contains(err.Error(), "missing device_id") {
+		t.Errorf("expected error to include response body, got: %v", err)
+	}
+}
+
+func TestVKIDProvider_Exchange_PassesDeviceID(t *testing.T) {
+	var captured string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		captured = r.FormValue("device_id")
+		_, _ = w.Write([]byte(`{"access_token":"t","user_id":1}`))
+	})
+	mux.HandleFunc("/user_info", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"user":{"user_id":"1","first_name":"X"}}`))
+	})
+	p, _ := newVKIDTestProvider(t, mux)
+
+	if _, err := p.Exchange(context.Background(), "c", "v", "dev-42"); err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if captured != "dev-42" {
+		t.Errorf("expected device_id=dev-42 in token form, got %q", captured)
 	}
 }
 
@@ -83,7 +122,7 @@ func TestVKIDProvider_Exchange_FallbackUserIDFromToken(t *testing.T) {
 	})
 	p, _ := newVKIDTestProvider(t, mux)
 
-	info, err := p.Exchange(context.Background(), "c", "v")
+	info, err := p.Exchange(context.Background(), "c", "v", "")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}

--- a/internal/auth/provider/yandex.go
+++ b/internal/auth/provider/yandex.go
@@ -59,7 +59,7 @@ func (p *YandexProvider) AuthorizationURL(state, codeChallenge string) string {
 	return p.authURL + "?" + q.Encode()
 }
 
-func (p *YandexProvider) Exchange(ctx context.Context, code, codeVerifier string) (*domain.ExternalUserInfo, error) {
+func (p *YandexProvider) Exchange(ctx context.Context, code, codeVerifier, _ string) (*domain.ExternalUserInfo, error) {
 	form := url.Values{}
 	form.Set("client_id", p.clientID)
 	form.Set("client_secret", p.clientSecret)

--- a/internal/auth/provider/yandex_test.go
+++ b/internal/auth/provider/yandex_test.go
@@ -44,7 +44,7 @@ func TestYandexProvider_Exchange_Success(t *testing.T) {
 	})
 	p, _ := newYandexTestProvider(t, mux)
 
-	info, err := p.Exchange(context.Background(), "code", "verifier")
+	info, err := p.Exchange(context.Background(), "code", "verifier", "")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestYandexProvider_Exchange_NoAvatar(t *testing.T) {
 	})
 	p, _ := newYandexTestProvider(t, mux)
 
-	info, err := p.Exchange(context.Background(), "c", "v")
+	info, err := p.Exchange(context.Background(), "c", "v", "")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}

--- a/internal/auth/usecase/oauth.go
+++ b/internal/auth/usecase/oauth.go
@@ -81,7 +81,7 @@ func (uc *OAuthUsecase) Start(ctx context.Context, providerName string) (string,
 	return authURL, state, expiresAt, nil
 }
 
-func (uc *OAuthUsecase) Callback(ctx context.Context, providerName, code, state string) (*domain.Session, *domain.User, error) {
+func (uc *OAuthUsecase) Callback(ctx context.Context, providerName, code, state, deviceID string) (*domain.Session, *domain.User, error) {
 	if code == "" || state == "" {
 		return nil, nil, fmt.Errorf("%w: code and state are required", domain.ErrInvalidInput)
 	}
@@ -102,7 +102,7 @@ func (uc *OAuthUsecase) Callback(ctx context.Context, providerName, code, state 
 		return nil, nil, fmt.Errorf("%w: state/provider mismatch", domain.ErrUnauthorized)
 	}
 
-	info, err := p.Exchange(ctx, code, stState.CodeVerifier)
+	info, err := p.Exchange(ctx, code, stState.CodeVerifier, deviceID)
 	if err != nil {
 		logger.Error(ctx, "usecase.oauth.Callback", "step", "exchange", "error", err, "provider", providerName)
 		return nil, nil, fmt.Errorf("%w: oauth exchange failed", domain.ErrUnauthorized)

--- a/internal/auth/usecase/oauth_test.go
+++ b/internal/auth/usecase/oauth_test.go
@@ -24,7 +24,7 @@ func (p *stubProvider) Name() string { return p.name }
 func (p *stubProvider) AuthorizationURL(state, challenge string) string {
 	return "https://provider.example/auth?state=" + state + "&c=" + challenge
 }
-func (p *stubProvider) Exchange(_ context.Context, _, _ string) (*domain.ExternalUserInfo, error) {
+func (p *stubProvider) Exchange(_ context.Context, _, _, _ string) (*domain.ExternalUserInfo, error) {
 	return p.info, p.err
 }
 
@@ -81,7 +81,7 @@ func TestOAuthUsecase_Callback_ExistingOAuthAccount(t *testing.T) {
 	d.userRepo.EXPECT().GetByID(gomock.Any(), int64(42)).Return(&domain.User{ID: 42, Email: "u@e.com", IsVerified: true}, nil)
 	d.sessRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
 
-	session, user, err := d.uc.Callback(context.Background(), domain.OAuthProviderGoogle, "code", "st")
+	session, user, err := d.uc.Callback(context.Background(), domain.OAuthProviderGoogle, "code", "st", "")
 	if err != nil {
 		t.Fatalf("Callback: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestOAuthUsecase_Callback_LinkByVerifiedEmail(t *testing.T) {
 	d.oauthRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(int64(11), nil)
 	d.sessRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
 
-	_, user, err := d.uc.Callback(context.Background(), domain.OAuthProviderGoogle, "code", "st")
+	_, user, err := d.uc.Callback(context.Background(), domain.OAuthProviderGoogle, "code", "st", "")
 	if err != nil {
 		t.Fatalf("Callback: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestOAuthUsecase_Callback_RejectUnverifiedExistingEmail(t *testing.T) {
 	d.oauthRepo.EXPECT().GetByProviderID(gomock.Any(), domain.OAuthProviderGoogle, "g-3").Return(nil, domain.ErrNotFound)
 	d.userRepo.EXPECT().GetByEmail(gomock.Any(), "u@e.com").Return(&domain.User{ID: 5, Email: "u@e.com", IsVerified: false}, nil)
 
-	_, _, err := d.uc.Callback(context.Background(), domain.OAuthProviderGoogle, "code", "st")
+	_, _, err := d.uc.Callback(context.Background(), domain.OAuthProviderGoogle, "code", "st", "")
 	if !errors.Is(err, domain.ErrConflict) {
 		t.Fatalf("want ErrConflict, got %v", err)
 	}
@@ -136,7 +136,7 @@ func TestOAuthUsecase_Callback_NewUserCreated(t *testing.T) {
 	d.oauthRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(int64(50), nil)
 	d.sessRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
 
-	_, user, err := d.uc.Callback(context.Background(), domain.OAuthProviderGoogle, "code", "st")
+	_, user, err := d.uc.Callback(context.Background(), domain.OAuthProviderGoogle, "code", "st", "")
 	if err != nil {
 		t.Fatalf("Callback: %v", err)
 	}
@@ -145,11 +145,40 @@ func TestOAuthUsecase_Callback_NewUserCreated(t *testing.T) {
 	}
 }
 
+func TestOAuthUsecase_Callback_NewUser_WritesEmptyPasswordHash(t *testing.T) {
+	info := &domain.ExternalUserInfo{ProviderID: "g-x", Email: "e@e.com", EmailVerified: true, Username: "U"}
+	d := newOAuthEnv(t, info)
+
+	d.stateRepo.EXPECT().Consume(gomock.Any(), "st").Return(&domain.OAuthState{Provider: domain.OAuthProviderGoogle, CodeVerifier: "v"}, nil)
+	d.oauthRepo.EXPECT().GetByProviderID(gomock.Any(), domain.OAuthProviderGoogle, "g-x").Return(nil, domain.ErrNotFound)
+	d.userRepo.EXPECT().GetByEmail(gomock.Any(), "e@e.com").Return(nil, domain.ErrNotFound)
+	d.userRepo.EXPECT().GetByUsername(gomock.Any(), "U").Return(nil, domain.ErrNotFound)
+
+	var captured *domain.User
+	d.userRepo.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, u *domain.User) (int64, error) {
+		captured = u
+		return 100, nil
+	})
+	d.userRepo.EXPECT().SetVerified(gomock.Any(), int64(100), true).Return(nil)
+	d.oauthRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(int64(1), nil)
+	d.sessRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
+
+	if _, _, err := d.uc.Callback(context.Background(), domain.OAuthProviderGoogle, "code", "st", ""); err != nil {
+		t.Fatalf("Callback: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("expected userRepo.Create to be invoked")
+	}
+	if captured.PasswordHash != "" {
+		t.Errorf("expected empty password_hash for oauth user (relies on migration 021), got %q", captured.PasswordHash)
+	}
+}
+
 func TestOAuthUsecase_Callback_StateExpired(t *testing.T) {
 	d := newOAuthEnv(t, nil)
 	d.stateRepo.EXPECT().Consume(gomock.Any(), "bad").Return(nil, domain.ErrNotFound)
 
-	_, _, err := d.uc.Callback(context.Background(), domain.OAuthProviderGoogle, "c", "bad")
+	_, _, err := d.uc.Callback(context.Background(), domain.OAuthProviderGoogle, "c", "bad", "")
 	if !errors.Is(err, domain.ErrUnauthorized) {
 		t.Fatalf("want ErrUnauthorized, got %v", err)
 	}

--- a/internal/gateway/handler/oauth_handler.go
+++ b/internal/gateway/handler/oauth_handler.go
@@ -93,6 +93,7 @@ func (h *OAuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		Provider: providerName,
 		Code:     code,
 		State:    state,
+		DeviceId: r.URL.Query().Get("device_id"),
 	})
 	if err != nil {
 		domainErr := grpcutil.GRPCToDomainError(err)

--- a/migrations/021_oauth_password_check.sql
+++ b/migrations/021_oauth_password_check.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_password_hash_not_empty;
+ALTER TABLE users
+    ADD CONSTRAINT users_password_hash_check
+    CHECK (password_hash IS NULL OR password_hash <> '');


### PR DESCRIPTION
## Summary

OAuth login was broken for all three providers on prod (`colkiss.ru`). Root causes were distinct, hence two commits:

1. **Google + Yandex** — migration 020 only dropped `NOT NULL` on `users.password_hash` but left the check constraint `users_password_hash_not_empty CHECK (password_hash <> '')` intact. `createOAuthUser` writes `""`, which hit pq 23514. Migration 021 replaces the constraint with `password_hash IS NULL OR password_hash <> ''` — empty oauth hashes are allowed, locals stay guarded.

2. **VK ID** — VK 2.x requires `device_id` (delivered as callback query param) in the token exchange or returns 200 with empty `access_token`. Threaded `device_id` through `OAuthCallbackRequest` proto → `OAuthUsecase.Callback` → `OAuthProvider.Exchange` interface → `vkid.go` form. Google/Yandex ignore the new param. Additionally dumped VK response body into errors at both decode points so future failures surface `error_description` instead of opaque "empty access_token".
